### PR TITLE
feat(): fetch coverart images for releases

### DIFF
--- a/examples/fetch_release_coverart.rs
+++ b/examples/fetch_release_coverart.rs
@@ -1,0 +1,14 @@
+extern crate musicbrainz_rs;
+
+use musicbrainz_rs::entity::release::*;
+use musicbrainz_rs::FetchCoverart;
+
+fn main() {
+    let in_utero_coverart = Release::fetch_coverart()
+        .id("76df3287-6cda-33eb-8e9a-044b5e15ffdd")
+        .execute()
+        .expect("Unable to get cover art");
+
+    assert_eq!(in_utero_coverart.images[0].front, true);
+    assert_eq!(in_utero_coverart.images[0].back, false);
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 pub(crate) const BASE_URL: &str = "http://musicbrainz.org/ws/2";
+pub(crate) const BASE_COVERART_URL: &str = "http://coverartarchive.org";
 pub(crate) const FMT_JSON: &str = "?fmt=json";
 pub(crate) const PARAM_INC: &str = "&inc=";
 

--- a/src/entity/coverart.rs
+++ b/src/entity/coverart.rs
@@ -1,0 +1,92 @@
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct Coverart {
+    pub images: Vec<CoverartImage>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct CoverartImage {
+    pub approved: bool,
+    pub back: bool,
+    pub comment: String,
+    pub edit: u64,
+    pub front: bool,
+    pub id: u64,
+    pub image: String,
+    pub thumbnails: Thumbnail,
+    pub types: Vec<ImageType>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct Thumbnail {
+    /// This is now deprecated in MusicBrainz API. Use `res_250` instead.
+    pub small: Option<String>,
+    /// khis is now deprecated in MusicBrainz API. Use `res_500` instead.
+    pub large: Option<String>,
+
+    #[serde(rename = "1200")]
+    pub res_1200: Option<String>,
+    #[serde(rename = "500")]
+    pub res_500: Option<String>,
+    #[serde(rename = "250")]
+    pub res_250: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub enum ImageType {
+    /// The album cover, this is the front of the packaging of an audio recording (or in the
+    /// case of a digital release the image associated with it in a digital media store).
+    Front,
+
+    /// The back of the package of an audio recording, this will often contain the track
+    /// listing, barcode and copyright information.
+    Back,
+
+    /// A small book or group of pages inserted into the compact disc or DVD jewel case or
+    /// the equivalent packaging for vinyl records and cassettes.
+    Booklet,
+
+    /// The medium contains the audio recording. For a compact disc release it is the compact
+    /// disc itself, for a vinyl release it is the vinyl disc itself, etc.
+    Medium,
+
+    /// The image behind or on the tray containing the medium.
+    Tray,
+
+    /// An obi is a strip of paper around the spine (or occasionally one of the other edges of the packaging).
+    Obi,
+
+    /// A spine is the edge of the package of an audio recording, it is often the only part
+    /// visible when recordings are stacked or stored in a shelf.
+    Spine,
+
+    /// Digital releases sometimes have cover art associated with each individual track of a
+    /// release (typically embedded in the .mp3 files), use this type for images associated
+    /// with individual tracks.
+    Track,
+
+    /// A liner is a protective sleeve surrounding a medium (usually a vinyl record, but sometimes
+    /// a CD), often printed with notes or images.
+    Liner,
+
+    /// A sticker is an adhesive piece of paper, that is attached to the plastic film or enclosed
+    /// inside the packaging.
+    Sticker,
+
+    /// A poster included with a release. May be the same size as the packaging or larger
+    /// (in this case it would fold out).
+    Poster,
+
+    /// A watermark is a piece of text or an image which is not part of the cover art but is
+    /// added by the person who scanned the cover art. Images without any watermarks are preferred
+    /// where possible - this type is useful in cases where either the only available image is
+    /// watermarked, or where a better quality watermarked image is uploaded alongside a poorer
+    /// quality non-watermarked image.
+    Watermark,
+
+    /// Select this type when uploading images that are usable for reference, but need more work to
+    /// be usable for tagging (for example, uncropped scans like the one below).
+    Raw,
+
+    /// Anything which doesn't fit in the types defined above.
+    Other,
+}

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -11,6 +11,7 @@ use crate::entity::series::Series;
 use crate::entity::url::Url;
 use crate::entity::work::Work;
 use crate::Fetch;
+use crate::FetchCoverart;
 use crate::Path;
 use crate::{Browse, Search};
 
@@ -58,6 +59,7 @@ pub mod alias;
 pub mod area;
 pub mod artist;
 pub mod artist_credit;
+pub mod coverart;
 pub mod event;
 pub mod genre;
 pub mod instrument;
@@ -87,6 +89,8 @@ impl Fetch<'_> for Instrument {}
 impl Fetch<'_> for Place {}
 impl Fetch<'_> for Series {}
 impl Fetch<'_> for Url {}
+
+impl FetchCoverart<'_> for Release {}
 
 impl Browse<'_> for Artist {}
 impl Browse<'_> for Area {}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,5 @@
 pub use crate::Browse;
 pub use crate::Error;
 pub use crate::Fetch;
+pub use crate::FetchCoverart;
 pub use crate::Search;

--- a/tests/release/mod.rs
+++ b/tests/release/mod.rs
@@ -1,2 +1,3 @@
 mod release_browse;
+mod release_coverart;
 mod release_includes;

--- a/tests/release/release_coverart.rs
+++ b/tests/release/release_coverart.rs
@@ -1,0 +1,18 @@
+extern crate musicbrainz_rs;
+
+use musicbrainz_rs::entity::release::*;
+use musicbrainz_rs::FetchCoverart;
+use std::{thread, time};
+
+#[test]
+fn should_get_release_coverart() {
+    let in_utero_coverart = Release::fetch_coverart()
+        .id("76df3287-6cda-33eb-8e9a-044b5e15ffdd")
+        .execute()
+        .expect("Unable to get cover art");
+
+    assert_eq!(in_utero_coverart.images[0].front, true);
+    assert_eq!(in_utero_coverart.images[0].back, false);
+
+    thread::sleep(time::Duration::from_secs(1));
+}


### PR DESCRIPTION
This PR adds method(s) for fetching coverart for release entities. I have a few concerns:

----------

I've had to change the type for `Release::ID` and `Release::Title` attributes to an `Option`, since the coverart API doesn't return these values. Is this going to be okay? Since we do not treat these two attributes as an `Option` for other entities.

---------

It seems like the coverart API returns an inconsistent response depending on the MBID. For example, the release entity `76df3287-6cda-33eb-8e9a-044b5e15ffdd` returns the value of the key `ID` in the json response as an integer.
https://coverartarchive.org/release/76df3287-6cda-33eb-8e9a-044b5e15ffdd?fmt=json

While, the release entity `18d4e9b4-9247-4b44-914a-8ddec3502103` treats the value of `ID` as a string (in quotes) in the json response.
https://coverartarchive.org/release/18d4e9b4-9247-4b44-914a-8ddec3502103?fmt=json

In this PR, I've assumed them as an integer but our json parser breaks in cases it receives a string for `ID` (since it expects an integer). Is this a bug in the web API and should be reported?

----------

I've yet to work on the builder pattern which looks like:
```rust
let in_utero = Release::fetch_coverart()
        .id("18d4e9b4-9247-4b44-914a-8ddec3502103")
        .back() // back/front
        .250()  // 250/500/1200
        .execute()
        .expect("Unable to get coverart"); 
```
as you mentioned in https://github.com/oknozor/musicbrainz_rs/issues/28#issuecomment-803539050.

I wanted to get some feedback before on the current work so far, whether or not is this the right way to implement coverart? What the current usage looks like can be seen from `tests/release/release_coverart.rs`.