### PR TITLE
fix(artist): fix artist fuzzy search

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ fn main() {
         .execute();
 
     let artists_on_in_utero_release = artists_on_in_utero_release.unwrap();
-    
+
     artists_on_in_utero_release
         .entities
         .iter()
@@ -110,7 +110,7 @@ fn main() {
     musicbrainz_rs::config::set_user_agent("my_awesome_app/1.0");
 
     let query = Artist::query_builder()
-        .name("Miles Davis")
+        .artist("Miles Davis")
         .and()
         .country("US")
         .build();

--- a/crates-io.md
+++ b/crates-io.md
@@ -88,7 +88,7 @@ fn main() {
         .execute();
 
     let artists_on_in_utero_release = artists_on_in_utero_release.unwrap();
-    
+
     artists_on_in_utero_release
         .entities
         .iter()
@@ -110,7 +110,7 @@ fn main() {
     musicbrainz_rs::config::set_user_agent("my_awesome_app/1.0");
 
     let query = Artist::query_builder()
-        .name("Miles Davis")
+        .artist("Miles Davis")
         .and()
         .country("US")
         .build();

--- a/examples/search_artist.rs
+++ b/examples/search_artist.rs
@@ -5,7 +5,7 @@ fn main() {
     musicbrainz_rs::config::set_user_agent("my_awesome_app/1.0");
 
     let query = Artist::query_builder()
-        .name("Miles Davis")
+        .artist("Miles Davis")
         .and()
         .country("US")
         .build();

--- a/src/entity/artist.rs
+++ b/src/entity/artist.rs
@@ -25,6 +25,7 @@ pub struct Artist {
     pub id: String,
 
     /// The official name of an artist, be it a person or a band.
+    #[query_builder_rename = "artist"]
     pub name: String,
 
     /// The sort name is a variant of the artist name which would be used when sorting artists by

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ pub struct BrowseQuery<T>(Query<T>);
 /// # fn main() -> Result<(), Error> {
 /// # use musicbrainz_rs::entity::artist::Artist;
 /// let query = Artist::query_builder()
-///         .name("Miles Davis")
+///         .artist("Miles Davis")
 ///         .and()
 ///         .country("US")
 ///         .build();

--- a/tests/artist/artist_search.rs
+++ b/tests/artist/artist_search.rs
@@ -7,7 +7,7 @@ use std::{thread, time};
 #[test]
 fn should_search_artist() {
     let query = Artist::query_builder()
-        .name("Nirvana")
+        .artist("Nirvana")
         .and()
         .artist_type("Group")
         .build();


### PR DESCRIPTION
Musicbrainz officially uses the "artist" field to search for artists,
and this has been giving incorrect results when trying to fuzzy search
through the "name" field.

See #23 for more details.