### PR TITLE
feat(coverart): implement get_coverart method

### DIFF
--- a/examples/fetch_release_coverart.rs
+++ b/examples/fetch_release_coverart.rs
@@ -1,6 +1,7 @@
 extern crate musicbrainz_rs;
 
 use musicbrainz_rs::entity::release::*;
+use musicbrainz_rs::prelude::*;
 use musicbrainz_rs::FetchCoverart;
 
 fn main() {
@@ -8,6 +9,19 @@ fn main() {
         .id("76df3287-6cda-33eb-8e9a-044b5e15ffdd")
         .execute()
         .expect("Unable to get cover art");
+
+    assert_eq!(in_utero_coverart.images[0].front, true);
+    assert_eq!(in_utero_coverart.images[0].back, false);
+
+    let in_utero = Release::fetch()
+        .id("76df3287-6cda-33eb-8e9a-044b5e15ffdd")
+        .execute()
+        .expect("Unable to get release");
+
+    let in_utero_coverart = in_utero
+        .get_coverart()
+        .execute()
+        .expect("Unable to get coverart");
 
     assert_eq!(in_utero_coverart.images[0].front, true);
     assert_eq!(in_utero_coverart.images[0].back, false);

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -1,3 +1,6 @@
+use std::marker::PhantomData;
+
+use crate::config::*;
 use crate::entity::area::Area;
 use crate::entity::artist::Artist;
 use crate::entity::event::Event;
@@ -11,9 +14,10 @@ use crate::entity::series::Series;
 use crate::entity::url::Url;
 use crate::entity::work::Work;
 use crate::Fetch;
-use crate::FetchCoverart;
 use crate::Path;
+use crate::Query;
 use crate::{Browse, Search};
+use crate::{FetchCoverart, FetchCoverartQuery};
 
 macro_rules! impl_includes {
     ($ty: ty, $(($args:ident, $inc: expr)),+) => {
@@ -55,6 +59,22 @@ macro_rules! impl_browse {
         }
 }
 
+macro_rules! impl_fetchcoverart {
+    ($($t: ty), +) => {
+        $(impl<'a> FetchCoverart<'a> for $t {
+            fn get_coverart(&self) -> FetchCoverartQuery<Self> {
+                let mut coverart_query = FetchCoverartQuery(Query {
+                    path: format!("{}/{}", BASE_COVERART_URL, Self::path()),
+                    phantom: PhantomData,
+                    include: vec![],
+                });
+                coverart_query.id(&self.id);
+                coverart_query
+            }
+        })+
+    }
+}
+
 pub mod alias;
 pub mod area;
 pub mod artist;
@@ -90,7 +110,7 @@ impl Fetch<'_> for Place {}
 impl Fetch<'_> for Series {}
 impl Fetch<'_> for Url {}
 
-impl FetchCoverart<'_> for Release {}
+impl_fetchcoverart!(Release, ReleaseGroup);
 
 impl Browse<'_> for Artist {}
 impl Browse<'_> for Area {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,6 +295,18 @@ pub trait FetchCoverart<'a> {
             include: vec![],
         })
     }
+
+    fn get_coverart(&self) -> FetchCoverartQuery<Self>
+    where
+        Self: Sized + Path<'a>,
+        Self: Clone,
+    {
+        FetchCoverartQuery(Query {
+            path: format!("{}/{}", BASE_COVERART_URL, Self::path()),
+            phantom: PhantomData,
+            include: vec![],
+        })
+    }
 }
 
 /// Implemented by all browsable entities (see [`BrowseQuery`])

--- a/tests/release/release_coverart.rs
+++ b/tests/release/release_coverart.rs
@@ -1,6 +1,7 @@
 extern crate musicbrainz_rs;
 
 use musicbrainz_rs::entity::release::*;
+use musicbrainz_rs::Fetch;
 use musicbrainz_rs::FetchCoverart;
 
 #[test]
@@ -9,6 +10,22 @@ fn should_get_release_coverart() {
         .id("76df3287-6cda-33eb-8e9a-044b5e15ffdd")
         .execute()
         .expect("Unable to get cover art");
+
+    assert_eq!(in_utero_coverart.images[0].front, true);
+    assert_eq!(in_utero_coverart.images[0].back, false);
+}
+
+#[test]
+fn should_get_release_coverart_after_fetch() {
+    let in_utero = Release::fetch()
+        .id("76df3287-6cda-33eb-8e9a-044b5e15ffdd")
+        .execute()
+        .expect("Unable to get release");
+
+    let in_utero_coverart = in_utero
+        .get_coverart()
+        .execute()
+        .expect("Unable to get coverart");
 
     assert_eq!(in_utero_coverart.images[0].front, true);
     assert_eq!(in_utero_coverart.images[0].back, false);

--- a/tests/release_group/mod.rs
+++ b/tests/release_group/mod.rs
@@ -1,2 +1,3 @@
 mod release_group_browse;
+mod release_group_coverart;
 mod release_group_includes;

--- a/tests/release_group/release_group_coverart.rs
+++ b/tests/release_group/release_group_coverart.rs
@@ -1,0 +1,33 @@
+extern crate musicbrainz_rs;
+
+use musicbrainz_rs::entity::release_group::*;
+use musicbrainz_rs::Fetch;
+use musicbrainz_rs::FetchCoverart;
+use std::{thread, time};
+
+#[test]
+fn should_get_release_group_coverart() {
+    let echoes_coverart = ReleaseGroup::fetch_coverart()
+        .id("ccdb3c9b-67e8-46f5-803f-026ef815ceea")
+        .execute()
+        .expect("Unable to get cover art");
+
+    assert_eq!(echoes_coverart.images[0].front, true);
+    assert_eq!(echoes_coverart.images[0].back, false);
+}
+
+#[test]
+fn should_get_release_group_coverart_after_fetch() {
+    let echoes = ReleaseGroup::fetch()
+        .id("ccdb3c9b-67e8-46f5-803f-026ef815ceea")
+        .execute()
+        .expect("Unable to get release");
+
+    let echoes_coverart = echoes
+        .get_coverart()
+        .execute()
+        .expect("Unable to get coverart");
+
+    assert_eq!(echoes_coverart.images[0].front, true);
+    assert_eq!(echoes_coverart.images[0].back, false);
+}


### PR DESCRIPTION
I used a macro to make the `impl for SomeStruct` more generalized. Not sure if there is a better way.

I'm open to any suggestions if anything can be improved here!