### PR TITLE
feat(coverart): coverart builder to make specific queries to coverart api

### DIFF
--- a/examples/fetch_release_coverart.rs
+++ b/examples/fetch_release_coverart.rs
@@ -1,6 +1,7 @@
 extern crate musicbrainz_rs;
 
 use musicbrainz_rs::entity::release::*;
+use musicbrainz_rs::entity::CoverartResponse;
 use musicbrainz_rs::prelude::*;
 use musicbrainz_rs::FetchCoverart;
 
@@ -10,8 +11,12 @@ fn main() {
         .execute()
         .expect("Unable to get cover art");
 
-    assert_eq!(in_utero_coverart.images[0].front, true);
-    assert_eq!(in_utero_coverart.images[0].back, false);
+    if let CoverartResponse::Json(coverart) = in_utero_coverart {
+        println!("{}", coverart.images[0].back);
+        println!("{}", coverart.images[0].image);
+    }
+
+    println!("");
 
     let in_utero = Release::fetch()
         .id("76df3287-6cda-33eb-8e9a-044b5e15ffdd")
@@ -23,6 +28,21 @@ fn main() {
         .execute()
         .expect("Unable to get coverart");
 
-    assert_eq!(in_utero_coverart.images[0].front, true);
-    assert_eq!(in_utero_coverart.images[0].back, false);
+    if let CoverartResponse::Json(coverart) = in_utero_coverart {
+        println!("{}", coverart.images[0].back);
+        println!("{}", coverart.images[0].image);
+    }
+
+    println!("");
+
+    let in_utero_500px_front_coverart = Release::fetch_coverart()
+        .id("76df3287-6cda-33eb-8e9a-044b5e15ffdd")
+        .res_500()
+        .back()
+        .execute()
+        .expect("Unable to get cover art");
+
+    if let CoverartResponse::Url(coverart_url) = in_utero_500px_front_coverart {
+        println!("{}", coverart_url);
+    }
 }

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use crate::config::*;
 use crate::entity::area::Area;
 use crate::entity::artist::Artist;
+use crate::entity::coverart::Coverart;
 use crate::entity::event::Event;
 use crate::entity::instrument::*;
 use crate::entity::label::Label;
@@ -15,9 +16,8 @@ use crate::entity::url::Url;
 use crate::entity::work::Work;
 use crate::Fetch;
 use crate::Path;
-use crate::Query;
 use crate::{Browse, Search};
-use crate::{FetchCoverart, FetchCoverartQuery};
+use crate::{CoverartQuery, FetchCoverart, FetchCoverartQuery};
 
 macro_rules! impl_includes {
     ($ty: ty, $(($args:ident, $inc: expr)),+) => {
@@ -63,10 +63,13 @@ macro_rules! impl_fetchcoverart {
     ($($t: ty), +) => {
         $(impl<'a> FetchCoverart<'a> for $t {
             fn get_coverart(&self) -> FetchCoverartQuery<Self> {
-                let mut coverart_query = FetchCoverartQuery(Query {
+                let mut coverart_query = FetchCoverartQuery(CoverartQuery {
                     path: format!("{}/{}", BASE_COVERART_URL, Self::path()),
                     phantom: PhantomData,
-                    include: vec![],
+                    target: CoverartTarget {
+                        img_type: None,
+                        img_res: None,
+                    },
                 });
                 coverart_query.id(&self.id);
                 coverart_query
@@ -370,4 +373,48 @@ impl Browsable for Instrument {
     const COUNT_FIELD: &'static str = "instrument-count";
     const OFFSET_FIELD: &'static str = "instrument-offset";
     const ENTITIES_FIELD: &'static str = "instruments";
+}
+
+#[derive(Clone, Debug)]
+pub struct CoverartTarget {
+    pub img_type: Option<CoverartType>,
+    pub img_res: Option<CoverartResolution>,
+}
+
+#[derive(Clone, Debug)]
+pub enum CoverartResponse {
+    Json(Coverart),
+    Url(String),
+}
+
+#[derive(Clone, Debug)]
+pub enum CoverartType {
+    Front,
+    Back,
+}
+
+impl CoverartType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CoverartType::Front => "front",
+            CoverartType::Back => "back",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum CoverartResolution {
+    Res250,
+    Res500,
+    Res1200,
+}
+
+impl CoverartResolution {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CoverartResolution::Res250 => "250",
+            CoverartResolution::Res500 => "500",
+            CoverartResolution::Res1200 => "1200",
+        }
+    }
 }

--- a/tests/release/release_coverart.rs
+++ b/tests/release/release_coverart.rs
@@ -1,6 +1,7 @@
 extern crate musicbrainz_rs;
 
 use musicbrainz_rs::entity::release::*;
+use musicbrainz_rs::entity::CoverartResponse;
 use musicbrainz_rs::Fetch;
 use musicbrainz_rs::FetchCoverart;
 
@@ -11,8 +12,12 @@ fn should_get_release_coverart() {
         .execute()
         .expect("Unable to get cover art");
 
-    assert_eq!(in_utero_coverart.images[0].front, true);
-    assert_eq!(in_utero_coverart.images[0].back, false);
+    if let CoverartResponse::Json(coverart) = in_utero_coverart {
+        assert_eq!(coverart.images[0].front, true);
+        assert_eq!(coverart.images[0].back, false);
+    } else {
+        assert!(false);
+    }
 }
 
 #[test]
@@ -27,6 +32,10 @@ fn should_get_release_coverart_after_fetch() {
         .execute()
         .expect("Unable to get coverart");
 
-    assert_eq!(in_utero_coverart.images[0].front, true);
-    assert_eq!(in_utero_coverart.images[0].back, false);
+    if let CoverartResponse::Json(coverart) = in_utero_coverart {
+        assert_eq!(coverart.images[0].front, true);
+        assert_eq!(coverart.images[0].back, false);
+    } else {
+        assert!(false);
+    }
 }

--- a/tests/release_group/release_group_coverart.rs
+++ b/tests/release_group/release_group_coverart.rs
@@ -1,9 +1,9 @@
 extern crate musicbrainz_rs;
 
 use musicbrainz_rs::entity::release_group::*;
+use musicbrainz_rs::entity::CoverartResponse;
 use musicbrainz_rs::Fetch;
 use musicbrainz_rs::FetchCoverart;
-use std::{thread, time};
 
 #[test]
 fn should_get_release_group_coverart() {
@@ -12,8 +12,12 @@ fn should_get_release_group_coverart() {
         .execute()
         .expect("Unable to get cover art");
 
-    assert_eq!(echoes_coverart.images[0].front, true);
-    assert_eq!(echoes_coverart.images[0].back, false);
+    if let CoverartResponse::Json(coverart) = echoes_coverart {
+        assert_eq!(coverart.images[0].front, true);
+        assert_eq!(coverart.images[0].back, false);
+    } else {
+        assert!(false);
+    }
 }
 
 #[test]
@@ -28,6 +32,10 @@ fn should_get_release_group_coverart_after_fetch() {
         .execute()
         .expect("Unable to get coverart");
 
-    assert_eq!(echoes_coverart.images[0].front, true);
-    assert_eq!(echoes_coverart.images[0].back, false);
+    if let CoverartResponse::Json(coverart) = echoes_coverart {
+        assert_eq!(coverart.images[0].front, true);
+        assert_eq!(coverart.images[0].back, false);
+    } else {
+        assert!(false);
+    }
 }


### PR DESCRIPTION
Ideally this will allow us to make specific calls to the coverart api. Such as to fetch front coverart for some release in 500px:
```rust
// https://coverartarchive.org/release/76df3287-6cda-33eb-8e9a-044b5e15ffdd/front-500
let in_utero_coverart = Release::fetch_coverart()
    .id("76df3287-6cda-33eb-8e9a-044b5e15ffdd")
    .front()
    .res_500()
    .execute()
    .expect("Unable to get cover art");
```
I'm not sure what the return type in our library should be here. The coverart api simply returns an image for this query. 

Should we also return an image (maybe through the [`image`](https://docs.rs/image/latest/image/) crate), or maybe just return the redirect url from the original query (which looks like `https://ia802607.us.archive.org/32/items/mbid-76df3287-6cda-33eb-8e9a-044b5e15ffdd/mbid-76df3287-6cda-33eb-8e9a-044b5e15ffdd-829521842_thumb500.jpg`)?

Also, currently `FetchCoverartQuery::execute()` expects response content to be in json, but making these specific coverart calls does not return json. Not sure what the best way to deal with this in our library is.