### PR TITLE
feat(): implement auto-retries

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,18 +1,24 @@
 use reqwest::header;
 use reqwest::Client;
+use reqwest::Error;
 use reqwest::RequestBuilder;
+use reqwest::Response;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::{thread, time::Duration};
 
 pub(crate) const BASE_URL: &str = "http://musicbrainz.org/ws/2";
 pub(crate) const BASE_COVERART_URL: &str = "http://coverartarchive.org";
 pub(crate) const FMT_JSON: &str = "?fmt=json";
 pub(crate) const PARAM_INC: &str = "&inc=";
+const HTTP_RATELIMIT_CODE: u16 = 503;
 
 pub(crate) struct MusicBrainzClient(Arc<Mutex<Client>>);
+struct MusicBrainzRetries(Arc<Mutex<u32>>);
 
 lazy_static! {
     pub(crate) static ref HTTP_CLIENT: MusicBrainzClient = init_http_client();
+    static ref HTTP_RETRIES: MusicBrainzRetries = init_http_retries();
 }
 
 impl MusicBrainzClient {
@@ -20,6 +26,26 @@ impl MusicBrainzClient {
         let client_ref = Arc::clone(&HTTP_CLIENT.0);
         let client_lock = client_ref.lock().expect("Unable to get musicbrainz client");
         client_lock.get(path)
+    }
+
+    pub(crate) fn send_with_retries(&self, request: RequestBuilder) -> Result<Response, Error> {
+        let mut retries = *HTTP_RETRIES.0.lock().unwrap();
+        loop {
+            let request = request.try_clone().unwrap();
+            let response = request.send()?;
+            if response.status().as_u16() == HTTP_RATELIMIT_CODE && retries > 0 {
+                let headers = response.headers();
+                let retry_secs = headers.get("retry-after").unwrap().to_str().unwrap();
+                // It seems like the value in the response header is sometimes rounded-off to the
+                // lower number, which can be lower than when the server actually accepts the next
+                // request. So we add one to the received duration to account for this.
+                let duration = Duration::from_secs(retry_secs.parse::<u64>().unwrap() + 1);
+                thread::sleep(duration);
+                retries -= 1;
+            } else {
+                break Ok(response);
+            }
+        }
     }
 }
 
@@ -36,6 +62,13 @@ fn init_http_client() -> MusicBrainzClient {
 
     MusicBrainzClient {
         0: Arc::new(Mutex::new(client)),
+    }
+}
+
+fn init_http_retries() -> MusicBrainzRetries {
+    let retries = 2;
+    MusicBrainzRetries {
+        0: Arc::new(Mutex::new(retries)),
     }
 }
 
@@ -65,4 +98,12 @@ pub fn set_user_agent(user_agent: &'static str) {
         .default_headers(headers)
         .build()
         .expect("Unable to set user agent");
+}
+
+pub fn set_default_retries(retries: u32) {
+    let retries_ref = Arc::clone(&HTTP_RETRIES.0);
+    let mut retries_lock = retries_ref
+        .lock()
+        .expect("Unable to set musicbrainz client retries");
+    *retries_lock = retries;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,8 @@ where
     {
         self.0.path.push_str(FMT_JSON);
         self.include_to_path();
-        HTTP_CLIENT.get(&self.0.path).send()?.json()
+        let request = HTTP_CLIENT.get(&self.0.path);
+        HTTP_CLIENT.send_with_retries(request)?.json()
     }
 
     fn include_to_path(&mut self) {
@@ -202,7 +203,8 @@ where
     }
 
     pub fn execute(&mut self) -> Result<Coverart, Error> {
-        HTTP_CLIENT.get(&self.0.path).send()?.json()
+        let request = HTTP_CLIENT.get(&self.0.path);
+        HTTP_CLIENT.send_with_retries(request)?.json()
     }
 }
 
@@ -215,7 +217,8 @@ where
         T: Fetch<'a> + DeserializeOwned + Browsable,
     {
         self.include_to_path();
-        HTTP_CLIENT.get(&self.0.path).send()?.json()
+        let request = HTTP_CLIENT.get(&self.0.path);
+        HTTP_CLIENT.send_with_retries(request)?.json()
     }
 
     fn include_to_path(&mut self) {
@@ -232,7 +235,8 @@ where
         T: Search<'a> + DeserializeOwned + Searchable,
     {
         self.include_to_path();
-        HTTP_CLIENT.get(&self.0.path).send()?.json()
+        let request = HTTP_CLIENT.get(&self.0.path);
+        HTTP_CLIENT.send_with_retries(request)?.json()
     }
 
     fn include_to_path(&mut self) {

--- a/tests/area/area_browse.rs
+++ b/tests/area/area_browse.rs
@@ -2,8 +2,6 @@ extern crate musicbrainz_rs;
 
 use musicbrainz_rs::entity::area::*;
 use musicbrainz_rs::prelude::*;
-use std::thread;
-use std::time::Duration;
 
 // TODO: find non empty result
 #[test]
@@ -13,5 +11,4 @@ fn browse_area_by_collection() {
         .execute();
 
     assert!(areas.is_ok());
-    thread::sleep(Duration::from_secs(1));
 }

--- a/tests/area/area_includes.rs
+++ b/tests/area/area_includes.rs
@@ -2,7 +2,6 @@ extern crate musicbrainz_rs;
 
 use musicbrainz_rs::entity::area::*;
 use musicbrainz_rs::prelude::*;
-use std::{thread, time};
 
 #[test]
 fn should_get_area_tags() {
@@ -13,8 +12,6 @@ fn should_get_area_tags() {
         .unwrap();
 
     assert!(aberdeen.tags.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -26,8 +23,6 @@ fn should_get_area_aliases() {
         .unwrap();
 
     assert!(aberdeen.aliases.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -39,8 +34,6 @@ fn should_get_area_genres() {
         .unwrap();
 
     assert!(aberdeen.genres.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -52,6 +45,4 @@ fn should_get_area_annotation() {
         .unwrap();
 
     assert!(london.annotation.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }

--- a/tests/artist/artist_browse.rs
+++ b/tests/artist/artist_browse.rs
@@ -3,7 +3,6 @@ extern crate musicbrainz_rs;
 
 use musicbrainz_rs::entity::artist::*;
 use musicbrainz_rs::prelude::*;
-use std::{thread, time};
 
 #[test]
 fn should_browse_artist_by_release_groups() {
@@ -18,8 +17,6 @@ fn should_browse_artist_by_release_groups() {
     assert_eq!(artistss_on_in_rainbows_rg.count, 1);
     assert_eq!(artistss_on_in_rainbows_rg.offset, 0);
     assert!(!artistss_on_in_rainbows_rg.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -35,8 +32,6 @@ fn should_browse_artist_by_release() {
     assert_eq!(artists_on_in_utero_release.count, 1);
     assert_eq!(artists_on_in_utero_release.offset, 0);
     assert!(!artists_on_in_utero_release.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -52,8 +47,6 @@ fn should_browse_artist_by_area() {
     assert!(artistss_in_aberdeen_area.count > 0);
     assert_eq!(artistss_in_aberdeen_area.offset, 0);
     assert!(!artistss_in_aberdeen_area.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -67,8 +60,6 @@ fn should_browse_artist_by_work() {
     assert!(artists_on_hotel_california.count > 1);
     assert_eq!(artists_on_hotel_california.offset, 0);
     assert!(!artists_on_hotel_california.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -82,6 +73,4 @@ fn should_browse_artist_by_recording() {
     assert!(artists_on_polly.count == 1);
     assert_eq!(artists_on_polly.offset, 0);
     assert!(!artists_on_polly.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }

--- a/tests/artist/artist_includes.rs
+++ b/tests/artist/artist_includes.rs
@@ -3,7 +3,6 @@ extern crate musicbrainz_rs;
 
 use musicbrainz_rs::entity::artist::*;
 use musicbrainz_rs::prelude::*;
-use std::{thread, time};
 
 #[test]
 fn should_get_artist_releases() {
@@ -18,8 +17,6 @@ fn should_get_artist_releases() {
     assert!(releases
         .iter()
         .any(|release| release.title == "Boogie Chillen’ / Sally Mae"));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -35,8 +32,6 @@ fn should_get_artist_works() {
     assert!(works
         .iter()
         .any(|work| work.title == "Baby Please Don't Go"));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -55,8 +50,6 @@ fn should_get_artist_release_groups() {
     assert!(release_groups
         .iter()
         .any(|group| group.title == "Travelin’"));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -72,8 +65,6 @@ fn should_get_artist_recordings() {
     assert!(recordings
         .iter()
         .any(|recording| recording.title == "(Blues Is) The Healer"));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -107,8 +98,6 @@ fn should_get_artist_artist_relations() {
     assert!(relations
         .iter()
         .any(|rel| rel.relation_type == "main performer"));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -124,8 +113,6 @@ fn should_get_artist_artist_releases_with_disc_ids() {
     assert!(releases_with_disc_ids
         .iter()
         .any(|release| release.title == "Smells Like Teen Spirit"));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -141,8 +128,6 @@ fn should_get_artist_tags() {
         .unwrap()
         .iter()
         .any(|tag| tag.name == "chicago blues"));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -154,8 +139,6 @@ fn should_get_artist_rating() {
         .unwrap();
 
     assert!(john_lee_hooker.rating.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -171,8 +154,6 @@ fn should_get_artist_genres() {
         .unwrap()
         .iter()
         .any(|genre| genre.name == "blues"));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -184,6 +165,4 @@ fn should_get_artist_annotation() {
         .unwrap();
 
     assert!(franz_joseph_haydn.annotation.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }

--- a/tests/artist/artist_search.rs
+++ b/tests/artist/artist_search.rs
@@ -2,7 +2,6 @@ extern crate musicbrainz_rs;
 
 use musicbrainz_rs::entity::artist::*;
 use musicbrainz_rs::Search;
-use std::{thread, time};
 
 #[test]
 fn should_search_artist() {
@@ -15,6 +14,4 @@ fn should_search_artist() {
     let result = Artist::search(query).execute().unwrap();
 
     assert!(!result.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }

--- a/tests/event/event_browse.rs
+++ b/tests/event/event_browse.rs
@@ -3,7 +3,6 @@ extern crate musicbrainz_rs;
 
 use musicbrainz_rs::entity::event::*;
 use musicbrainz_rs::prelude::*;
-use std::{thread, time};
 
 #[test]
 fn should_browse_event_by_place() {
@@ -18,8 +17,6 @@ fn should_browse_event_by_place() {
     assert!(events_in_north_stage_woodstock_1994.count > 1);
     assert_eq!(events_in_north_stage_woodstock_1994.offset, 0);
     assert!(!events_in_north_stage_woodstock_1994.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -35,8 +32,6 @@ fn should_browse_event_by_artist() {
     assert!(events_with_aerosmith.count > 1);
     assert_eq!(events_with_aerosmith.offset, 0);
     assert!(!events_with_aerosmith.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -52,6 +47,4 @@ fn should_browse_event_by_area() {
     assert!(events_in_montreux.count > 1);
     assert_eq!(events_in_montreux.offset, 0);
     assert!(!events_in_montreux.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }

--- a/tests/event/event_includes.rs
+++ b/tests/event/event_includes.rs
@@ -1,7 +1,6 @@
 extern crate musicbrainz_rs;
 use musicbrainz_rs::entity::event::Event;
 use musicbrainz_rs::prelude::*;
-use std::{thread, time};
 
 #[test]
 fn should_get_event_tags() {
@@ -12,8 +11,6 @@ fn should_get_event_tags() {
         .unwrap();
 
     assert!(dour_festival_1989.tags.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -25,8 +22,6 @@ fn should_get_event_aliases() {
         .unwrap();
 
     assert!(dour_festival_1989.aliases.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -38,8 +33,6 @@ fn should_get_event_rating() {
         .unwrap();
 
     assert!(dour_festival_1989.rating.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -51,8 +44,6 @@ fn should_get_event_genres() {
         .unwrap();
 
     assert!(dour_festival_1989.genres.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -64,6 +55,4 @@ fn should_get_event_annotation() {
         .unwrap();
 
     assert!(kiss_at_huntington_center.annotation.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }

--- a/tests/fetch.rs
+++ b/tests/fetch.rs
@@ -18,7 +18,6 @@ use musicbrainz_rs::entity::series::*;
 use musicbrainz_rs::entity::url::*;
 use musicbrainz_rs::entity::work::*;
 use musicbrainz_rs::prelude::*;
-use std::{thread, time};
 
 #[test]
 fn should_get_artist_by_id() {
@@ -81,8 +80,6 @@ fn should_get_artist_by_id() {
             annotation: None,
         }
     );
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -109,7 +106,6 @@ fn should_get_recording_by_id() {
             annotation: None,
         }
     );
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -138,8 +134,6 @@ fn should_get_release_group_by_id() {
             annotation: None,
         }
     );
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -196,8 +190,6 @@ fn should_get_work_by_id() {
             annotation: None,
         }
     );
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -225,8 +217,6 @@ fn should_get_label_by_id() {
             annotation: None,
         }
     );
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -256,8 +246,6 @@ fn should_get_area_by_id() {
             }),
         }
     );
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -312,8 +300,6 @@ fn should_get_instrument() {
             annotation: None,
         }
     );
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -360,8 +346,6 @@ fn should_get_place() {
             annotation: None,
         }
     );
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -384,8 +368,6 @@ fn should_get_series() {
             annotation: None,
         }
     );
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -402,6 +384,4 @@ fn should_get_url() {
             tags: None,
         }
     );
-
-    thread::sleep(time::Duration::from_secs(1));
 }

--- a/tests/instrument/instrument_browse.rs
+++ b/tests/instrument/instrument_browse.rs
@@ -2,8 +2,6 @@ extern crate musicbrainz_rs;
 
 use self::musicbrainz_rs::entity::instrument::Instrument;
 use musicbrainz_rs::prelude::*;
-use std::thread;
-use std::time::Duration;
 
 // TODO: find non empty result
 #[test]
@@ -14,6 +12,4 @@ fn browse_instrument_by_collection() {
 
     assert!(instruments.is_ok());
     let _instruments = instruments.unwrap();
-
-    thread::sleep(Duration::from_secs(1));
 }

--- a/tests/instrument/instrument_includes.rs
+++ b/tests/instrument/instrument_includes.rs
@@ -1,7 +1,6 @@
 extern crate musicbrainz_rs;
 use musicbrainz_rs::entity::instrument::Instrument;
 use musicbrainz_rs::prelude::*;
-use std::{thread, time};
 
 #[test]
 fn should_get_instrument_tags() {
@@ -12,8 +11,6 @@ fn should_get_instrument_tags() {
         .unwrap();
 
     assert!(guitar.tags.unwrap().iter().any(|tag| tag.name == "wood"));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -29,8 +26,6 @@ fn should_get_instrument_aliases() {
         .unwrap()
         .iter()
         .any(|alias| alias.name == "guitarras"));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -42,8 +37,6 @@ fn should_get_instrument_genres() {
         .unwrap();
 
     assert!(guitar.genres.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -55,6 +48,4 @@ fn should_get_instrument_annotation() {
         .unwrap();
 
     assert!(gusli.annotation.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }

--- a/tests/label/label_browse.rs
+++ b/tests/label/label_browse.rs
@@ -3,7 +3,6 @@ extern crate musicbrainz_rs;
 
 use musicbrainz_rs::entity::label::*;
 use musicbrainz_rs::prelude::*;
-use std::{thread, time};
 
 #[test]
 fn should_browse_label_by_area() {
@@ -18,8 +17,6 @@ fn should_browse_label_by_area() {
     assert!(labels_in_paris.count > 1);
     assert_eq!(labels_in_paris.offset, 0);
     assert!(!labels_in_paris.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -35,8 +32,6 @@ fn should_browse_label_by_release() {
     assert!(label_of_justice_cross_release.count > 1);
     assert_eq!(label_of_justice_cross_release.offset, 0);
     assert!(!label_of_justice_cross_release.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 // TODO: find non empty result
@@ -49,6 +44,4 @@ fn should_browse_label_by_collection() {
     assert!(label_on_collection.is_ok());
 
     let _label_on_collection = label_on_collection.unwrap();
-
-    thread::sleep(time::Duration::from_secs(1));
 }

--- a/tests/label/label_includes.rs
+++ b/tests/label/label_includes.rs
@@ -1,7 +1,6 @@
 extern crate musicbrainz_rs;
 use self::musicbrainz_rs::entity::label::Label;
 use musicbrainz_rs::prelude::*;
-use std::{thread, time};
 
 #[test]
 fn should_get_label_releases() {
@@ -16,8 +15,6 @@ fn should_get_label_releases() {
         .unwrap()
         .iter()
         .any(|release| release.title == "The Final Corporate Colonization of the Unconscious"));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -30,8 +27,6 @@ fn should_get_label_aliases() {
     let aliases = motown.unwrap().aliases;
 
     assert!(aliases.unwrap().iter().any(|alias| alias.name == "Motown"));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -47,8 +42,6 @@ fn should_get_label_tags() {
         .unwrap()
         .iter()
         .any(|tag| tag.name == "independent"));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -60,8 +53,6 @@ fn should_get_label_rating() {
         .unwrap();
 
     assert!(ninja_tune.rating.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -73,8 +64,6 @@ fn should_get_label_genres() {
         .unwrap();
 
     assert!(ninja_tune.genres.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -86,6 +75,4 @@ fn should_get_label_annotation() {
         .unwrap();
 
     assert!(tokuma_japan_communications.annotation.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }

--- a/tests/place/place_browse.rs
+++ b/tests/place/place_browse.rs
@@ -3,7 +3,6 @@ extern crate musicbrainz_rs;
 
 use musicbrainz_rs::entity::place::*;
 use musicbrainz_rs::prelude::*;
-use std::{thread, time};
 
 #[test]
 fn should_browse_place_by_area() {
@@ -18,8 +17,6 @@ fn should_browse_place_by_area() {
     assert!(places_in_paris.count > 1);
     assert_eq!(places_in_paris.offset, 0);
     assert!(!places_in_paris.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 // TODO: find non empty result
@@ -30,5 +27,4 @@ fn should_browse_place_by_collection() {
         .execute();
 
     assert!(places_in_collection.is_ok());
-    thread::sleep(time::Duration::from_secs(1));
 }

--- a/tests/place/place_includes.rs
+++ b/tests/place/place_includes.rs
@@ -1,7 +1,6 @@
 extern crate musicbrainz_rs;
 use musicbrainz_rs::entity::place::*;
 use musicbrainz_rs::prelude::*;
-use std::{thread, time};
 
 #[test]
 fn should_get_place_aliases() {
@@ -12,8 +11,6 @@ fn should_get_place_aliases() {
         .unwrap();
 
     assert!(blue_note.aliases.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -25,8 +22,6 @@ fn should_get_place_tags() {
         .unwrap();
 
     assert!(olympia.tags.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 #[test]
 fn should_get_place_genres() {
@@ -37,8 +32,6 @@ fn should_get_place_genres() {
         .unwrap();
 
     assert!(olympia.genres.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -50,6 +43,4 @@ fn should_get_place_annotation() {
         .unwrap();
 
     assert!(osaka_kosei_nenkin_kaikan.annotation.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }

--- a/tests/recording/recording_browse.rs
+++ b/tests/recording/recording_browse.rs
@@ -3,7 +3,6 @@ extern crate musicbrainz_rs;
 
 use musicbrainz_rs::entity::recording::*;
 use musicbrainz_rs::prelude::*;
-use std::{thread, time};
 
 #[test]
 fn should_browse_recording_by_artist() {
@@ -18,8 +17,6 @@ fn should_browse_recording_by_artist() {
     assert!(recording_by_svinkels.count > 1);
     assert_eq!(recording_by_svinkels.offset, 0);
     assert!(!recording_by_svinkels.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -35,8 +32,6 @@ fn should_browse_recording_work() {
     assert!(la_javanaise_recordings.count > 1);
     assert_eq!(la_javanaise_recordings.offset, 0);
     assert!(!la_javanaise_recordings.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -52,6 +47,4 @@ fn should_browse_recording_by_release() {
     assert!(recording_on_hooker_n_heat.count > 1);
     assert_eq!(recording_on_hooker_n_heat.offset, 0);
     assert!(!recording_on_hooker_n_heat.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }

--- a/tests/recording/recording_includes.rs
+++ b/tests/recording/recording_includes.rs
@@ -1,7 +1,6 @@
 extern crate musicbrainz_rs;
 use musicbrainz_rs::entity::recording::*;
 use musicbrainz_rs::prelude::*;
-use std::{thread, time};
 
 #[test]
 fn should_get_recording_artists() {
@@ -14,8 +13,6 @@ fn should_get_recording_artists() {
 
     assert!(artist_credit.iter().any(|credit| credit.name == "TTC"));
     assert!(artist_credit.iter().any(|credit| credit.name == "Svinkels"));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -31,8 +28,6 @@ fn should_get_recording_releases() {
         .unwrap()
         .iter()
         .any(|release| release.title == "Hooker ’n Heat"));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -45,8 +40,6 @@ fn should_get_recording_aliases() {
     let aliases = you_talk_too_much.unwrap().aliases;
 
     assert!(aliases.is_some()); // FIXME: didn't find a recording containing actual aliases (yet)
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -58,8 +51,6 @@ fn should_get_recording_tags() {
         .unwrap();
 
     assert!(you_talk_too_much.tags.is_some()); // FIXME: didn't find a recording containing actual aliases (yet)
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -71,8 +62,6 @@ fn should_get_recording_rating() {
         .unwrap();
 
     assert!(you_talk_too_much.rating.is_some()); // FIXME: didn't find a recording containing actual aliases (yet)
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -84,8 +73,6 @@ fn should_get_recording_genres() {
         .unwrap();
 
     assert!(you_talk_too_much.genres.is_some()); // FIXME: didn't find a recording containing actual aliases (yet)
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -97,6 +84,4 @@ fn should_get_recording_annotation() {
         .unwrap();
 
     assert!(isolina.annotation.is_some()); // FIXME: didn't find a recording containing actual aliases (yet)
-
-    thread::sleep(time::Duration::from_secs(1));
 }

--- a/tests/release/release_browse.rs
+++ b/tests/release/release_browse.rs
@@ -3,7 +3,6 @@ extern crate musicbrainz_rs;
 
 use musicbrainz_rs::entity::release::*;
 use musicbrainz_rs::prelude::*;
-use std::{thread, time};
 
 #[test]
 fn should_browse_release_by_artist() {
@@ -18,8 +17,6 @@ fn should_browse_release_by_artist() {
     assert!(releases_by_svinkels.count > 1);
     assert_eq!(releases_by_svinkels.offset, 0);
     assert!(!releases_by_svinkels.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -35,8 +32,6 @@ fn should_browse_release_by_area() {
     assert!(releases_france.count > 1);
     assert_eq!(releases_france.offset, 0);
     assert!(!releases_france.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -52,8 +47,6 @@ fn should_browse_release_by_label() {
     assert!(ninjatune_releases.count > 1);
     assert_eq!(ninjatune_releases.offset, 0);
     assert!(!ninjatune_releases.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -69,8 +62,6 @@ fn should_browse_release_by_recording() {
     assert!(release_of_l_ecole_du_micro_d_argent.count > 1);
     assert_eq!(release_of_l_ecole_du_micro_d_argent.offset, 0);
     assert!(!release_of_l_ecole_du_micro_d_argent.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -86,8 +77,6 @@ fn should_browse_release_by_track() {
     assert!(release_with_phantom_by_justice.count > 0);
     assert_eq!(release_with_phantom_by_justice.offset, 0);
     assert!(!release_with_phantom_by_justice.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -103,8 +92,6 @@ fn should_browse_release_by_track_artist() {
     assert!(release_featuring_akhenaton.count > 1);
     assert_eq!(release_featuring_akhenaton.offset, 0);
     assert!(!release_featuring_akhenaton.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -119,8 +106,6 @@ fn should_browse_release_by_track_artist_with_recordings() {
     let release = &release_featuring_akhenaton.entities[0];
     let medias = release.media.as_ref().unwrap();
     assert!(!medias.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -136,8 +121,6 @@ fn should_browse_release_by_release_group() {
     assert!(neil_young_harvest_releases.count > 1);
     assert_eq!(neil_young_harvest_releases.offset, 0);
     assert!(!neil_young_harvest_releases.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -153,6 +136,4 @@ fn should_browse_release_by_collection() {
     assert!(releases_in_collection.count > 1);
     assert_eq!(releases_in_collection.offset, 0);
     assert!(!releases_in_collection.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }

--- a/tests/release/release_coverart.rs
+++ b/tests/release/release_coverart.rs
@@ -2,7 +2,6 @@ extern crate musicbrainz_rs;
 
 use musicbrainz_rs::entity::release::*;
 use musicbrainz_rs::FetchCoverart;
-use std::{thread, time};
 
 #[test]
 fn should_get_release_coverart() {
@@ -13,6 +12,4 @@ fn should_get_release_coverart() {
 
     assert_eq!(in_utero_coverart.images[0].front, true);
     assert_eq!(in_utero_coverart.images[0].back, false);
-
-    thread::sleep(time::Duration::from_secs(1));
 }

--- a/tests/release/release_includes.rs
+++ b/tests/release/release_includes.rs
@@ -2,7 +2,6 @@ extern crate musicbrainz_rs;
 use musicbrainz_rs::entity::release::Media;
 use musicbrainz_rs::entity::release::Release;
 use musicbrainz_rs::prelude::*;
-use std::{thread, time};
 
 #[test]
 fn should_get_release_release_groups() {
@@ -13,8 +12,6 @@ fn should_get_release_release_groups() {
         .unwrap();
 
     assert_eq!(justice_cross.release_group.unwrap().title, "✝");
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -30,8 +27,6 @@ fn should_get_release_media() {
         .unwrap()
         .iter()
         .any(|media| media.format.as_ref().unwrap() == "CD"));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -51,8 +46,6 @@ fn should_get_release_recordings() {
         .unwrap()
         .iter()
         .any(|track| track.title == "D.A.N.C.E."));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -68,8 +61,6 @@ fn should_get_release_label() {
         .unwrap()
         .iter()
         .any(|label_info| label_info.label.name == "Ed Banger Records"));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -85,8 +76,6 @@ fn should_get_release_tags() {
         .unwrap()
         .iter()
         .any(|tag| tag.name == "hip hop"));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -98,8 +87,6 @@ fn should_get_release_aliases() {
         .unwrap();
 
     assert!(l_ecole_du_micro_d_argent.aliases.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -111,8 +98,6 @@ fn should_get_release_genres() {
         .unwrap();
 
     assert!(l_ecole_du_micro_d_argent.genres.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -124,6 +109,4 @@ fn should_get_release_annotation() {
         .unwrap();
 
     assert!(pieds_nus_sur_la_braise.annotation.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }

--- a/tests/release_group/release_group_browse.rs
+++ b/tests/release_group/release_group_browse.rs
@@ -3,7 +3,6 @@ extern crate musicbrainz_rs;
 
 use musicbrainz_rs::entity::release_group::*;
 use musicbrainz_rs::prelude::*;
-use std::{thread, time};
 
 #[test]
 fn should_browse_release_group_by_artist() {
@@ -18,8 +17,6 @@ fn should_browse_release_group_by_artist() {
     assert!(release_groups_by_svinkels.count > 1);
     assert_eq!(release_groups_by_svinkels.offset, 0);
     assert!(!release_groups_by_svinkels.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -35,8 +32,6 @@ fn should_browse_release_group_by_release() {
     assert!(release_groups_of_we_want_miles.count > 0);
     assert_eq!(release_groups_of_we_want_miles.offset, 0);
     assert!(!release_groups_of_we_want_miles.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 // TODO: find non empty result
@@ -47,5 +42,4 @@ fn should_browse_release_group_by_collection() {
         .execute();
 
     assert!(releases_group_in_collection.is_ok());
-    thread::sleep(time::Duration::from_secs(1));
 }

--- a/tests/release_group/release_group_includes.rs
+++ b/tests/release_group/release_group_includes.rs
@@ -1,6 +1,5 @@
 use musicbrainz_rs::entity::release_group::*;
 use musicbrainz_rs::prelude::*;
-use std::{thread, time};
 
 #[test]
 fn should_get_release_group_artists() {
@@ -15,8 +14,6 @@ fn should_get_release_group_artists() {
         .unwrap()
         .iter()
         .any(|credit| credit.artist.name == "Neil Young"));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -32,8 +29,6 @@ fn should_get_release_group_releases() {
         .unwrap()
         .iter()
         .any(|release| release.title == "Harvest" && release.country == Some("CA".to_string())));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -49,7 +44,6 @@ fn should_get_release_group_tags() {
         .unwrap()
         .iter()
         .any(|tag| tag.name == "rock_grunge"));
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -61,8 +55,6 @@ fn should_get_release_group_aliases() {
         .unwrap();
 
     assert!(in_utero.aliases.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -74,8 +66,6 @@ fn should_get_release_group_rating() {
         .unwrap();
 
     assert!(in_utero.rating.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -87,8 +77,6 @@ fn should_get_release_group_genres() {
         .unwrap();
 
     assert!(in_utero.genres.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -100,6 +88,4 @@ fn should_get_release_group_annotation() {
         .unwrap();
 
     assert!(minnesoda.annotation.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }

--- a/tests/series/series_includes.rs
+++ b/tests/series/series_includes.rs
@@ -1,7 +1,6 @@
 extern crate musicbrainz_rs;
 use musicbrainz_rs::entity::series::Series;
 use musicbrainz_rs::prelude::*;
-use std::{thread, time};
 
 #[test]
 fn should_get_serie_tags() {
@@ -16,8 +15,6 @@ fn should_get_serie_tags() {
         .unwrap()
         .iter()
         .any(|tag| tag.name == "breakbeat"));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -29,8 +26,6 @@ fn should_get_serie_aliases() {
         .unwrap();
 
     assert!(ultimate_breaks_and_beats.aliases.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -42,8 +37,6 @@ fn should_get_serie_genres() {
         .unwrap();
 
     assert!(ultimate_breaks_and_beats.genres.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -55,6 +48,4 @@ fn should_get_serie_annotation() {
         .unwrap();
 
     assert!(record_store_day_2020.annotation.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }

--- a/tests/work/work_browse.rs
+++ b/tests/work/work_browse.rs
@@ -3,7 +3,6 @@ extern crate musicbrainz_rs;
 
 use musicbrainz_rs::entity::work::*;
 use musicbrainz_rs::prelude::*;
-use std::{thread, time};
 
 #[test]
 fn should_browse_work_by_artist() {
@@ -18,8 +17,6 @@ fn should_browse_work_by_artist() {
     assert!(work_by_svinkels.count > 1);
     assert_eq!(work_by_svinkels.offset, 0);
     assert!(!work_by_svinkels.entities.is_empty());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 // TODO: find non empty result
@@ -30,5 +27,4 @@ fn should_browse_work_by_collection() {
         .execute();
 
     assert!(work_in_collection.is_ok());
-    thread::sleep(time::Duration::from_secs(1));
 }

--- a/tests/work/work_includes.rs
+++ b/tests/work/work_includes.rs
@@ -1,7 +1,6 @@
 extern crate musicbrainz_rs;
 use musicbrainz_rs::entity::work::Work;
 use musicbrainz_rs::prelude::*;
-use std::{thread, time};
 
 #[test]
 fn should_get_work_tags() {
@@ -16,8 +15,6 @@ fn should_get_work_tags() {
         .unwrap()
         .iter()
         .any(|tag| tag.name == "ripped off"));
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -29,8 +26,6 @@ fn should_get_work_aliases() {
         .unwrap();
 
     assert!(hotel_california.aliases.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -42,8 +37,6 @@ fn should_get_work_rating() {
         .unwrap();
 
     assert!(hotel_california.rating.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -55,8 +48,6 @@ fn should_get_work_genres() {
         .unwrap();
 
     assert!(hotel_california.genres.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }
 
 #[test]
@@ -68,6 +59,4 @@ fn should_get_work_annotation() {
         .unwrap();
 
     assert!(vater_unser_im_himmelreich.annotation.is_some());
-
-    thread::sleep(time::Duration::from_secs(1));
 }


### PR DESCRIPTION
This PR adds an auto-retry feature if a request fails due to being rate-limited by MusicBrainz servers. By default; every failed request will automatically be retried twice. This number can be changed by calling:
```rust
musicbrainz_rs::config::set_default_retries(3);
```
I've also removed the 1s sleep from all our tests, and our test-suite now runs much faster (~2 mins now, while it used to take ~3.5 mins previously!).

Closes #13.