### PR TITLE
chore: rename artist-rel inc for consistency

### DIFF
--- a/src/entity/area.rs
+++ b/src/entity/area.rs
@@ -28,7 +28,7 @@ impl_browse!(Area, (by_collection, BrowseBy::Collection));
 
 impl_includes!(
     Area,
-    (with_artists_relations, Include::ArtistRelations),
+    (with_artist_relations, Include::ArtistRelations),
     (with_tags, Include::Tags),
     (with_aliases, Include::Aliases),
     (with_genres, Include::Genres),


### PR DESCRIPTION
All other entities make use of `Include::ArtistRelations` through the builder method `with_artist_relations`, except in this case.