### PR TITLE
refactor(includes): split incs into variants

### DIFF
--- a/src/entity/area.rs
+++ b/src/entity/area.rs
@@ -1,4 +1,4 @@
-use super::Include;
+use super::{Include, Relationship, Subquery};
 use crate::entity::alias::Alias;
 use crate::entity::genre::Genre;
 use crate::entity::lifespan::LifeSpan;
@@ -28,9 +28,12 @@ impl_browse!(Area, (by_collection, BrowseBy::Collection));
 
 impl_includes!(
     Area,
-    (with_artist_relations, Include::ArtistRelations),
-    (with_tags, Include::Tags),
-    (with_aliases, Include::Aliases),
-    (with_genres, Include::Genres),
-    (with_annotations, Include::Annotations)
+    (
+        with_artist_relations,
+        Include::Relationship(Relationship::Artist)
+    ),
+    (with_tags, Include::Subquery(Subquery::Tags)),
+    (with_aliases, Include::Subquery(Subquery::Aliases)),
+    (with_genres, Include::Subquery(Subquery::Genres)),
+    (with_annotations, Include::Subquery(Subquery::Annotations))
 );

--- a/src/entity/artist.rs
+++ b/src/entity/artist.rs
@@ -155,6 +155,7 @@ impl_includes!(
         with_event_relations,
         Include::Relationship(Relationship::Event)
     ),
+    (with_url_relations, Include::Relationship(Relationship::Url)),
     (with_tags, Include::Subquery(Subquery::Tags)),
     (with_rating, Include::Subquery(Subquery::Rating)),
     (with_genres, Include::Subquery(Subquery::Genres)),

--- a/src/entity/artist.rs
+++ b/src/entity/artist.rs
@@ -1,4 +1,4 @@
-use super::Include;
+use super::{Include, Relationship, Subquery};
 use crate::entity::alias::Alias;
 use crate::entity::area::Area;
 use crate::entity::genre::Genre;
@@ -135,16 +135,28 @@ Artist,
 
 impl_includes!(
     Artist,
-    (with_recordings, Include::Recordings),
-    (with_releases, Include::Releases),
-    (with_releases_and_discids, Include::ReleasesWithDiscIds),
-    (with_release_groups, Include::ReleaseGroups),
-    (with_aliases, Include::Aliases),
-    (with_works, Include::Works),
-    (with_artist_relations, Include::ArtistRelations),
-    (with_event_relations, Include::EventRelations),
-    (with_tags, Include::Tags),
-    (with_rating, Include::Rating),
-    (with_genres, Include::Genres),
-    (with_annotations, Include::Annotations)
+    (with_recordings, Include::Subquery(Subquery::Recordings)),
+    (with_releases, Include::Subquery(Subquery::Releases)),
+    (
+        with_releases_and_discids,
+        Include::Subquery(Subquery::ReleasesWithDiscIds)
+    ),
+    (
+        with_release_groups,
+        Include::Subquery(Subquery::ReleaseGroups)
+    ),
+    (with_aliases, Include::Subquery(Subquery::Aliases)),
+    (with_works, Include::Subquery(Subquery::Works)),
+    (
+        with_artist_relations,
+        Include::Relationship(Relationship::Artist)
+    ),
+    (
+        with_event_relations,
+        Include::Relationship(Relationship::Event)
+    ),
+    (with_tags, Include::Subquery(Subquery::Tags)),
+    (with_rating, Include::Subquery(Subquery::Rating)),
+    (with_genres, Include::Subquery(Subquery::Genres)),
+    (with_annotations, Include::Subquery(Subquery::Annotations))
 );

--- a/src/entity/event.rs
+++ b/src/entity/event.rs
@@ -1,4 +1,4 @@
-use super::Include;
+use super::{Include, Relationship, Subquery};
 use crate::entity::alias::Alias;
 use crate::entity::genre::Genre;
 use crate::entity::lifespan::LifeSpan;
@@ -38,10 +38,13 @@ Event,
 
 impl_includes!(
     Event,
-    (with_artist_relations, Include::ArtistRelations),
-    (with_tags, Include::Tags),
-    (with_aliases, Include::Aliases),
-    (with_ratings, Include::Rating),
-    (with_genres, Include::Genres),
-    (with_annotations, Include::Annotations)
+    (
+        with_artist_relations,
+        Include::Relationship(Relationship::Artist)
+    ),
+    (with_tags, Include::Subquery(Subquery::Tags)),
+    (with_aliases, Include::Subquery(Subquery::Aliases)),
+    (with_ratings, Include::Subquery(Subquery::Rating)),
+    (with_genres, Include::Subquery(Subquery::Genres)),
+    (with_annotations, Include::Subquery(Subquery::Annotations))
 );

--- a/src/entity/instrument.rs
+++ b/src/entity/instrument.rs
@@ -1,4 +1,4 @@
-use super::Include;
+use super::{Include, Relationship, Subquery};
 use crate::entity::alias::Alias;
 use crate::entity::genre::Genre;
 use crate::entity::tag::Tag;
@@ -24,9 +24,12 @@ impl_browse!(Instrument, (by_collection, BrowseBy::Collection));
 
 impl_includes!(
     Instrument,
-    (with_artist_relations, Include::ArtistRelations),
-    (with_tags, Include::Tags),
-    (with_aliases, Include::Aliases),
-    (with_genres, Include::Genres),
-    (with_annotations, Include::Annotations)
+    (
+        with_artist_relations,
+        Include::Relationship(Relationship::Artist)
+    ),
+    (with_tags, Include::Subquery(Subquery::Tags)),
+    (with_aliases, Include::Subquery(Subquery::Aliases)),
+    (with_genres, Include::Subquery(Subquery::Genres)),
+    (with_annotations, Include::Subquery(Subquery::Annotations))
 );

--- a/src/entity/label.rs
+++ b/src/entity/label.rs
@@ -1,4 +1,4 @@
-use super::Include;
+use super::{Include, Subquery};
 use crate::entity::alias::Alias;
 use crate::entity::genre::Genre;
 use crate::entity::rating::Rating;
@@ -42,10 +42,10 @@ Label,
 
 impl_includes!(
     Label,
-    (with_releases, Include::Releases),
-    (with_tags, Include::Tags),
-    (with_aliases, Include::Aliases),
-    (with_ratings, Include::Rating),
-    (with_genres, Include::Genres),
-    (with_annotations, Include::Annotations)
+    (with_releases, Include::Subquery(Subquery::Releases)),
+    (with_tags, Include::Subquery(Subquery::Tags)),
+    (with_aliases, Include::Subquery(Subquery::Aliases)),
+    (with_ratings, Include::Subquery(Subquery::Rating)),
+    (with_genres, Include::Subquery(Subquery::Genres)),
+    (with_annotations, Include::Subquery(Subquery::Annotations))
 );

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -201,6 +201,22 @@ impl Path<'_> for Url {
 #[derive(Debug, PartialEq, Clone)]
 #[allow(unused)]
 pub(crate) enum Include {
+    Subquery(Subquery),
+    Relationship(Relationship),
+}
+
+impl Include {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Include::Subquery(i) => i.as_str(),
+            Include::Relationship(i) => i.as_str(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+#[allow(unused)]
+pub(crate) enum Subquery {
     Urls,
     Areas,
     ArtistCredits,
@@ -208,9 +224,6 @@ pub(crate) enum Include {
     Events,
     Places,
     DiscIds,
-    ArtistRelations,
-    EventRelations,
-    UrlRelations,
     Releases,
     ReleasesWithDiscIds,
     ReleaseGroups,
@@ -227,33 +240,48 @@ pub(crate) enum Include {
     ISRCs,
 }
 
-impl Include {
+impl Subquery {
     pub(crate) fn as_str(&self) -> &'static str {
         match self {
-            Include::Labels => "labels",
-            Include::Recordings => "recordings",
-            Include::Tags => "tags",
-            Include::Rating => "ratings",
-            Include::Aliases => "aliases",
-            Include::Genres => "genres",
-            Include::Annotations => "annotation",
-            Include::ArtistRelations => "artist-rels",
-            Include::EventRelations => "event-rels",
-            Include::UrlRelations => "url-rels",
-            Include::Releases => "releases",
-            Include::ReleaseGroups => "release-groups",
-            Include::Works => "works",
-            Include::Artists => "artists",
-            Include::Places => "places",
-            Include::Events => "events",
-            Include::Urls => "urls",
-            Include::Areas => "areas",
-            Include::ArtistCredits => "artist-credits",
-            Include::DiscIds => "discids",
-            Include::ReleasesWithDiscIds => "releases+discids",
-            Include::Instruments => "instruments",
-            Include::Series => "series",
-            Include::ISRCs => "isrcs",
+            Subquery::Labels => "labels",
+            Subquery::Recordings => "recordings",
+            Subquery::Tags => "tags",
+            Subquery::Rating => "ratings",
+            Subquery::Aliases => "aliases",
+            Subquery::Genres => "genres",
+            Subquery::Annotations => "annotation",
+            Subquery::Releases => "releases",
+            Subquery::ReleaseGroups => "release-groups",
+            Subquery::Works => "works",
+            Subquery::Artists => "artists",
+            Subquery::Places => "places",
+            Subquery::Events => "events",
+            Subquery::Urls => "urls",
+            Subquery::Areas => "areas",
+            Subquery::ArtistCredits => "artist-credits",
+            Subquery::DiscIds => "discids",
+            Subquery::ReleasesWithDiscIds => "releases+discids",
+            Subquery::Instruments => "instruments",
+            Subquery::Series => "series",
+            Subquery::ISRCs => "isrcs",
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+#[allow(unused)]
+pub(crate) enum Relationship {
+    Artist,
+    Event,
+    Url,
+}
+
+impl Relationship {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Relationship::Artist => "artist-rels",
+            Relationship::Event => "event-rels",
+            Relationship::Url => "url-rels",
         }
     }
 }

--- a/src/entity/place.rs
+++ b/src/entity/place.rs
@@ -1,4 +1,4 @@
-use super::Include;
+use super::{Include, Relationship, Subquery};
 use crate::entity::alias::Alias;
 use crate::entity::area::Area;
 use crate::entity::genre::Genre;
@@ -39,9 +39,12 @@ Place,
 
 impl_includes!(
     Place,
-    (with_artist_relations, Include::ArtistRelations),
-    (with_tags, Include::Tags),
-    (with_aliases, Include::Aliases),
-    (with_genres, Include::Genres),
-    (with_annotations, Include::Annotations)
+    (
+        with_artist_relations,
+        Include::Relationship(Relationship::Artist)
+    ),
+    (with_tags, Include::Subquery(Subquery::Tags)),
+    (with_aliases, Include::Subquery(Subquery::Aliases)),
+    (with_genres, Include::Subquery(Subquery::Genres)),
+    (with_annotations, Include::Subquery(Subquery::Annotations))
 );

--- a/src/entity/recording.rs
+++ b/src/entity/recording.rs
@@ -6,7 +6,7 @@ use crate::entity::relations::Relation;
 use crate::entity::release::Release;
 use crate::entity::tag::Tag;
 use crate::entity::BrowseBy;
-use crate::entity::Include;
+use crate::entity::{Include, Relationship, Subquery};
 
 /// A recording is an entity in MusicBrainz which can be linked to tracks on releases. Each track
 /// must always be associated with a single recording, but a recording can be linked to any number
@@ -57,13 +57,13 @@ Recording,
 
 impl_includes!(
     Recording,
-    (with_artists, Include::Artists),
-    (with_releases, Include::Releases),
-    (with_tags, Include::Tags),
-    (with_aliases, Include::Aliases),
-    (with_genres, Include::Genres),
-    (with_ratings, Include::Rating),
-    (with_isrcs, Include::ISRCs),
-    (with_url_relations, Include::UrlRelations),
-    (with_annotations, Include::Annotations)
+    (with_artists, Include::Subquery(Subquery::Artists)),
+    (with_releases, Include::Subquery(Subquery::Releases)),
+    (with_tags, Include::Subquery(Subquery::Tags)),
+    (with_aliases, Include::Subquery(Subquery::Aliases)),
+    (with_genres, Include::Subquery(Subquery::Genres)),
+    (with_ratings, Include::Subquery(Subquery::Rating)),
+    (with_isrcs, Include::Subquery(Subquery::ISRCs)),
+    (with_url_relations, Include::Relationship(Relationship::Url)),
+    (with_annotations, Include::Subquery(Subquery::Annotations))
 );

--- a/src/entity/release.rs
+++ b/src/entity/release.rs
@@ -185,6 +185,7 @@ impl_includes!(
         with_artist_relations,
         Include::Relationship(Relationship::Artist)
     ),
+    (with_url_relations, Include::Relationship(Relationship::Url)),
     (with_recordings, Include::Subquery(Subquery::Recordings)),
     (
         with_release_groups,

--- a/src/entity/release.rs
+++ b/src/entity/release.rs
@@ -1,6 +1,6 @@
 use chrono::NaiveDate;
 
-use super::Include;
+use super::{Include, Relationship, Subquery};
 use crate::date_format;
 use crate::entity::alias::Alias;
 use crate::entity::artist_credit::ArtistCredit;
@@ -179,14 +179,20 @@ Release,
 
 impl_includes!(
     Release,
-    (with_artists, Include::Artists),
-    (with_labels, Include::Labels),
-    (with_artist_relations, Include::ArtistRelations),
-    (with_recordings, Include::Recordings),
-    (with_release_groups, Include::ReleaseGroups),
-    (with_tags, Include::Tags),
-    (with_ratings, Include::Rating),
-    (with_aliases, Include::Aliases),
-    (with_genres, Include::Genres),
-    (with_annotations, Include::Annotations)
+    (with_artists, Include::Subquery(Subquery::Artists)),
+    (with_labels, Include::Subquery(Subquery::Labels)),
+    (
+        with_artist_relations,
+        Include::Relationship(Relationship::Artist)
+    ),
+    (with_recordings, Include::Subquery(Subquery::Recordings)),
+    (
+        with_release_groups,
+        Include::Subquery(Subquery::ReleaseGroups)
+    ),
+    (with_tags, Include::Subquery(Subquery::Tags)),
+    (with_ratings, Include::Subquery(Subquery::Rating)),
+    (with_aliases, Include::Subquery(Subquery::Aliases)),
+    (with_genres, Include::Subquery(Subquery::Genres)),
+    (with_annotations, Include::Subquery(Subquery::Annotations))
 );

--- a/src/entity/release_group.rs
+++ b/src/entity/release_group.rs
@@ -1,4 +1,4 @@
-use super::Include;
+use super::{Include, Subquery};
 use crate::date_format;
 use crate::entity::alias::Alias;
 use crate::entity::artist_credit::ArtistCredit;
@@ -54,11 +54,11 @@ ReleaseGroup,
 
 impl_includes!(
     ReleaseGroup,
-    (with_artists, Include::Artists),
-    (with_releases, Include::Releases),
-    (with_tags, Include::Tags),
-    (with_aliases, Include::Aliases),
-    (with_genres, Include::Genres),
-    (with_ratings, Include::Rating),
-    (with_annotations, Include::Annotations)
+    (with_artists, Include::Subquery(Subquery::Artists)),
+    (with_releases, Include::Subquery(Subquery::Releases)),
+    (with_tags, Include::Subquery(Subquery::Tags)),
+    (with_aliases, Include::Subquery(Subquery::Aliases)),
+    (with_genres, Include::Subquery(Subquery::Genres)),
+    (with_ratings, Include::Subquery(Subquery::Rating)),
+    (with_annotations, Include::Subquery(Subquery::Annotations))
 );

--- a/src/entity/series.rs
+++ b/src/entity/series.rs
@@ -1,4 +1,4 @@
-use super::Include;
+use super::{Include, Relationship, Subquery};
 use crate::entity::alias::Alias;
 use crate::entity::genre::Genre;
 use crate::entity::tag::Tag;
@@ -23,9 +23,12 @@ impl_browse!(Series, (by_collection, BrowseBy::Collection));
 
 impl_includes!(
     Series,
-    (with_artist_relations, Include::ArtistRelations),
-    (with_tags, Include::Tags),
-    (with_aliases, Include::Aliases),
-    (with_genres, Include::Genres),
-    (with_annotations, Include::Annotations)
+    (
+        with_artist_relations,
+        Include::Relationship(Relationship::Artist)
+    ),
+    (with_tags, Include::Subquery(Subquery::Tags)),
+    (with_aliases, Include::Subquery(Subquery::Aliases)),
+    (with_genres, Include::Subquery(Subquery::Genres)),
+    (with_annotations, Include::Subquery(Subquery::Annotations))
 );

--- a/src/entity/url.rs
+++ b/src/entity/url.rs
@@ -1,4 +1,4 @@
-use super::Include;
+use super::{Include, Relationship};
 use crate::entity::tag::Tag;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -10,6 +10,9 @@ pub struct Url {
 
 impl_includes!(
     Url,
-    (with_artist_relations, Include::ArtistRelations),
-    (with_url_relations, Include::UrlRelations)
+    (
+        with_artist_relations,
+        Include::Relationship(Relationship::Artist)
+    ),
+    (with_url_relations, Include::Relationship(Relationship::Url))
 );

--- a/src/entity/work.rs
+++ b/src/entity/work.rs
@@ -1,4 +1,4 @@
-use super::Include;
+use super::{Include, Relationship, Subquery};
 use crate::entity::alias::Alias;
 use crate::entity::genre::Genre;
 use crate::entity::rating::Rating;
@@ -36,10 +36,13 @@ Work,
 
 impl_includes!(
     Work,
-    (with_artist_relations, Include::ArtistRelations),
-    (with_tags, Include::Tags),
-    (with_ratings, Include::Rating),
-    (with_aliases, Include::Aliases),
-    (with_genres, Include::Genres),
-    (with_annotations, Include::Annotations)
+    (
+        with_artist_relations,
+        Include::Relationship(Relationship::Artist)
+    ),
+    (with_tags, Include::Subquery(Subquery::Tags)),
+    (with_ratings, Include::Subquery(Subquery::Rating)),
+    (with_aliases, Include::Subquery(Subquery::Aliases)),
+    (with_genres, Include::Subquery(Subquery::Genres)),
+    (with_annotations, Include::Subquery(Subquery::Annotations))
 );

--- a/tests/artist/artist_includes.rs
+++ b/tests/artist/artist_includes.rs
@@ -88,16 +88,42 @@ fn should_get_artist_artist_relations() {
     let john_lee_hooker = Artist::fetch()
         .id("b0122194-c49a-46a1-ade7-84d1d76bd8e9")
         .with_artist_relations()
-        .with_event_relations()
         .execute()
         .unwrap();
 
     let relations = john_lee_hooker.relations.unwrap();
 
     assert!(relations.iter().any(|rel| rel.relation_type == "parent"));
+}
+
+#[test]
+fn should_get_artist_event_relations() {
+    let john_lee_hooker = Artist::fetch()
+        .id("b0122194-c49a-46a1-ade7-84d1d76bd8e9")
+        .with_event_relations()
+        .execute()
+        .unwrap();
+
+    let relations = john_lee_hooker.relations.unwrap();
+
     assert!(relations
         .iter()
         .any(|rel| rel.relation_type == "main performer"));
+}
+
+#[test]
+fn should_get_artist_url_relations() {
+    let john_lee_hooker = Artist::fetch()
+        .id("b0122194-c49a-46a1-ade7-84d1d76bd8e9")
+        .with_url_relations()
+        .execute()
+        .unwrap();
+
+    let relations = john_lee_hooker.relations.unwrap();
+
+    assert!(relations
+        .iter()
+        .any(|rel| rel.relation_type == "BBC Music page"));
 }
 
 #[test]

--- a/tests/release/release_includes.rs
+++ b/tests/release/release_includes.rs
@@ -103,6 +103,19 @@ fn should_get_release_artist_relations() {
 }
 
 #[test]
+fn should_get_release_url_relations() {
+    let in_utero = Release::fetch()
+        .id("76df3287-6cda-33eb-8e9a-044b5e15ffdd")
+        .with_url_relations()
+        .execute()
+        .unwrap();
+
+    let relations = in_utero.relations.unwrap();
+
+    assert!(relations.iter().any(|rel| rel.relation_type == "discogs"));
+}
+
+#[test]
 fn should_get_release_aliases() {
     let l_ecole_du_micro_d_argent = Release::fetch()
         .id("cba0035e-d8c9-4390-8569-02bdadaf87d3")


### PR DESCRIPTION
I initially tried to implement an `Include` trait which would be carried to by `Subquery` and `Relationship` ([musicbrainz docs](https://musicbrainz.org/doc/MusicBrainz_API#Lookups)). However since size for traits isn't known by the compiler at compile-time so I'm not sure how we could modify [this](https://github.com/oknozor/musicbrainz_rs/blob/b72c31ebc75d2386479e2d3263f7795633ae9f1d/src/lib.rs#L66) to be considered valid code by the compiler. I think maybe `Box<T>` could help workaround this by allocating memory on the heap but I cannot seem to get it to work.

So I've used an enum based approach to deal with this at the moment. Not sure which is the better/best way though. I am open to any ideas.

Addresses https://github.com/oknozor/musicbrainz_rs/issues/9#issuecomment-867370925.