### PR TITLE
docs: cover more attributes

### DIFF
--- a/src/entity/alias.rs
+++ b/src/entity/alias.rs
@@ -1,6 +1,8 @@
 use crate::date_format;
 use chrono::NaiveDate;
 
+/// Aliases are used to store alternate names or misspellings. For more information and examples,
+/// see the page about [aliases](https://musicbrainz.org/doc/Aliases).
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Default)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 #[serde(default)]

--- a/src/entity/area.rs
+++ b/src/entity/area.rs
@@ -6,24 +6,60 @@ use crate::entity::relations::Relation;
 use crate::entity::tag::Tag;
 use crate::entity::BrowseBy;
 
+/// Areas are historical and existing geographic regions. Areas include countries, sub-divisions,
+/// counties, municipalities, cities, districts and islands.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Default)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 #[serde(default)]
 pub struct Area {
+    /// See [MusicBrainz Identifier](https://musicbrainz.org/doc/MusicBrainz_Identifier).
     pub id: String,
+    /// The type of area. Possible values are: Country, Subdivision, County, Municipality, City,
+    /// District, Island.
     #[serde(rename = "type")]
-    pub area_type: Option<String>,
-    pub type_id: Option<String>,
-    pub disambiguation: String,
+    pub area_type: Option<AreaType>,
+    /// The name of the area.
     pub name: String,
-    pub sort_name: String,
     pub relations: Option<Vec<Relation>>,
+    /// The ISO 3166 codes are the codes assigned by ISO to countries and subdivisions.
     pub iso_3166_1_codes: Option<Vec<String>>,
+    /// The aliases are used to store alternate names or misspellings.
+    pub aliases: Option<Vec<Alias>>,
+    /// Annotations are text fields, functioning like a miniature wiki, that can be added to any
+    /// existing artists, labels, recordings, releases, release groups and works.
+    pub annotation: Option<String>,
+    /// The disambiguation comments are fields in the database used to help distinguish identically
+    /// named artists, labels and other entities.
+    pub disambiguation: String,
+    pub type_id: Option<String>,
+    pub sort_name: String,
     pub life_span: Option<LifeSpan>,
     pub tags: Option<Vec<Tag>>,
-    pub aliases: Option<Vec<Alias>>,
     pub genres: Option<Vec<Genre>>,
-    pub annotation: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub enum AreaType {
+    /// Country is used for areas included (or previously included) in ISO 3166-1, e.g. United States.
+    Country,
+    /// Subdivision is used for the main administrative divisions of a country, e.g. California,
+    /// Ontario, Okinawa. These are considered when displaying the parent areas for a given area.
+    Subdivision,
+    /// County is used for smaller administrative divisions of a country which are not the main
+    /// administrative divisions but are also not municipalities, e.g. counties in the USA. These
+    /// are not considered when displaying the parent areas for a given area.
+    County,
+    /// Municipality is used for small administrative divisions which, for urban municipalities,
+    /// often contain a single city and a few surrounding villages. Rural municipalities typically
+    /// group several villages together.
+    Municipality,
+    /// City is used for settlements of any size, including towns and villages.
+    City,
+    /// District is used for a division of a large city, e.g. Queens.
+    District,
+    /// Island is used for islands and atolls which don't form subdivisions of their own, e.g. Skye.
+    /// These are not considered when displaying the parent areas for a given area.
+    Island,
 }
 
 impl_browse!(Area, (by_collection, BrowseBy::Collection));

--- a/src/entity/artist.rs
+++ b/src/entity/artist.rs
@@ -24,16 +24,15 @@ use lucene_query_builder::QueryBuilder;
 pub struct Artist {
     /// See [MusicBrainz Identifier](https://musicbrainz.org/doc/MusicBrainz_Identifier).
     pub id: String,
-
     /// The official name of an artist, be it a person or a band.
     pub name: String,
-
     /// The sort name is a variant of the artist name which would be used when sorting artists by
     /// name, such as in record shops or libraries. Among other things, sort names help to ensure
     /// that all the artists that start with "The" don't end up up under "T". The guidelines for
     /// sort names are the best place to check for more specific usage info.
     pub sort_name: String,
-
+    /// The disambiguation comments are fields in the database used to help distinguish identically
+    /// named artists, labels and other entities.
     pub disambiguation: String,
 
     /// The type is used to state whether an artist is a person, a group, or something else.
@@ -54,7 +53,11 @@ pub struct Artist {
     pub begin_area: Option<Area>, // all other field are deserialized in kebab-case
 
     pub relations: Option<Vec<Relation>>,
+    /// release represents the unique release (i.e. issuing) of a product on a specific date with
+    /// specific release information such as the country, label, barcode and packaging.
     pub releases: Option<Vec<Release>>,
+    /// A work is a distinct intellectual or artistic creation, which can be expressed in the form of
+    /// one or more audio recordings.
     pub works: Option<Vec<Work>>,
     pub release_groups: Option<Vec<ReleaseGroup>>,
     pub recordings: Option<Vec<Recording>>,
@@ -63,6 +66,8 @@ pub struct Artist {
     /// see the page about aliases.
     pub aliases: Option<Vec<Alias>>,
     pub tags: Option<Vec<Tag>>,
+
+    /// Genres are currently supported in MusicBrainz as part of the tag system.
     pub genres: Option<Vec<Genre>>,
     pub rating: Option<Rating>,
     pub country: Option<String>,

--- a/src/entity/artist_credit.rs
+++ b/src/entity/artist_credit.rs
@@ -1,5 +1,8 @@
 use crate::entity::artist::Artist;
 
+/// Artist credits indicate who is the main credited artist (or artists) for releases, release groups,
+/// tracks and recordings, and how they are credited. They consist of artists, with (optionally)
+/// their names as credited in the specific release, track, etc., and join phrases between them.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct ArtistCredit {
     pub name: String,

--- a/src/entity/disc.rs
+++ b/src/entity/disc.rs
@@ -1,8 +1,10 @@
+/// Disc ID is the code number which MusicBrainz uses to link a physical CD to a release listing.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub struct Disc {
-    pub id: String, 
+    /// See [MusicBrainz Identifier](https://musicbrainz.org/doc/MusicBrainz_Identifier).
+    pub id: String,
     pub offset_count: u32,
-    pub sectors: u32, 
+    pub sectors: u32,
     pub offsets : Vec<u32>
 }

--- a/src/entity/event.rs
+++ b/src/entity/event.rs
@@ -7,27 +7,87 @@ use crate::entity::relations::Relation;
 use crate::entity::tag::Tag;
 use crate::entity::BrowseBy;
 
+/// An event refers to an organised event which people can attend, and is relevant to MusicBrainz.
+/// Generally this means live performances, like concerts and festivals.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub struct Event {
+    /// See [MusicBrainz Identifier](https://musicbrainz.org/doc/MusicBrainz_Identifier).
     pub id: String,
+
+    /// The name is the official name of the event if it has one, or a descriptive name (like
+    /// "Main Artist at Place") if not.
     pub name: String,
+
+    /// The type describes what kind of event the event is. The possible values are: Concert,
+    /// Festival, Launch event, Convention/Expo, Masterclass/Clinic
+    // FIXME: Should we create an `EventType` enum and use it here? What do we then do about the
+    // values containing slashes, such as "Convention/Expo"?
+    // https://musicbrainz.org/ws/2/event/10b5e28b-95f5-482e-9524-c51be37f943d
     #[serde(rename = "type")]
     pub event_type: Option<String>,
-    pub type_id: Option<String>,
-    pub life_span: Option<LifeSpan>,
-    pub disambiguation: String,
+
+    /// The cancelled field describes whether or not the event took place.
     pub cancelled: bool,
+
+    /// The time is the start time of the event.
     pub time: String,
-    // need some info on that value, current IT test returns ""
+
+    /// The setlist stores a list of songs performed, optionally including links to artists and works.
+    /// See the setlist documentation for syntax and examples.
+    // TODO: need some info on that value, current IT test returns ""
     pub setlist: String,
+
     // same here
     pub tags: Option<Vec<Tag>>,
     pub relations: Option<Vec<Relation>>,
+
     pub rating: Option<Rating>,
+    /// Aliases are alternate names for an event, which currently have two main functions: localised
+    /// names and search hints. Localised names are used to store the official names used in different
+    /// languages and countries. These use the locale field to identify which language or country the
+    /// name is for. Search hints are used to help both users and the server when searching and can
+    /// be a number of things including alternate names, nicknames or even misspellings.
     pub aliases: Option<Vec<Alias>>,
-    pub genres: Option<Vec<Genre>>,
+
+    /// Annotations are text fields, functioning like a miniature wiki, that can be added to any
+    /// existing artists, labels, recordings, releases, release groups and works.
     pub annotation: Option<String>,
+
+    /// Genres are currently supported in MusicBrainz as part of the tag system.
+    pub genres: Option<Vec<Genre>>,
+
+    /// The begin and end dates indicate when an artist started and finished its existence.
+    /// Its exact meaning depends on the type of artist:
+    ///
+    ///  - For a person
+    ///        Begin date represents date of birth, and end date represents date of death.
+    ///
+    ///    - For a group (or orchestra/choir)
+    ///        Begin date represents the date when the group first formed: if a group dissolved and then
+    ///        reunited, the date is still that of when they first formed. End date represents the date
+    ///        when the group last dissolved: if a group dissolved and then reunited, the date is that
+    ///        of when they last dissolved (if they are together, it should be blank!). For listing
+    ///        other inactivity periods, just use the annotation and the "member of" relationships.
+    ///
+    ///    - For a character
+    ///        Begin date represents the date (in real life) when the character concept was created.
+    ///        The End date should not be set, since new media featuring a character can be created
+    ///        at any time. In particular, the Begin and End date fields should not be used to hold
+    ///        the fictional birth or death dates of a character.
+    ///        (This information can be put in the annotation.)
+    ///
+    ///    - For others
+    ///        There are no clear indications about how to use dates for artists of the type Other at
+    ///        the moment.
+    pub life_span: Option<LifeSpan>,
+
+    /// The disambiguation comments are fields in the database used to help distinguish identically
+    /// named artists, labels and other entities. They are visible in the pages for the entities, and
+    /// also appear in the search results next to their names.
+    pub disambiguation: String,
+
+    pub type_id: Option<String>,
 }
 
 impl_browse! {

--- a/src/entity/genre.rs
+++ b/src/entity/genre.rs
@@ -1,3 +1,6 @@
+/// Genres are currently supported in MusicBrainz as part of the tag system.
+/// See [Genre](https://musicbrainz.org/doc/Genre) and
+/// [supported genres](https://musicbrainz.org/genres) for more information.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub struct Genre {

--- a/src/entity/instrument.rs
+++ b/src/entity/instrument.rs
@@ -5,21 +5,64 @@ use crate::entity::relations::Relation;
 use crate::entity::tag::Tag;
 use crate::entity::BrowseBy;
 
+/// Instruments are devices created or adapted to make musical sounds. Instruments are primarily
+/// used in relationships between two other entities and for that, each instrument entity has a
+/// parallel relationship attribute with the same MBID. Instruments, like relationship attributes,
+/// can only be edited by relationship editors.
+/// See [Instrument List](https://musicbrainz.org/instruments) for the full list.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub struct Instrument {
+    /// See [MusicBrainz Identifier](https://musicbrainz.org/doc/MusicBrainz_Identifier).
     pub id: String,
+    /// The instrument name is the name of the instrument, typically the most common name in English.
     pub name: String,
+    /// The type categorises the instrument by the way the sound is created, similar to the
+    /// Hornbostel-Sachs classification. The possible values are: Wind instrument, String instrument,
+    /// Precussion instrument, Electronic instrument, Family, Ensemble, Other instrument.
     #[serde(rename = "type")]
-    pub instrument_type: String,
+    pub instrument_type: InstrumentType,
     pub type_id: String,
+    /// The description is a brief description of the main characteristics of the instrument.
     pub description: String,
+    /// The disambiguation comments are fields in the database used to help distinguish identically
+    /// named artists, labels and other entities.
     pub disambiguation: String,
     pub relations: Option<Vec<Relation>>,
     pub tags: Option<Vec<Tag>>,
+    /// Aliases are alternate names for an instrument, which currently have two main functions:
+    /// localised names and search hints.
     pub aliases: Option<Vec<Alias>>,
     pub genres: Option<Vec<Genre>>,
+    /// Annotations are text fields, functioning like a miniature wiki, that can be added to any
+    /// existing artists, labels, recordings, releases, release groups and works.
     pub annotation: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub enum InstrumentType {
+    /// An aerophone, i.e. an instrument where the sound is created by vibrating air. The instrument
+    /// itself does not vibrate.
+    #[serde(rename = "Wind instrument")]
+    WindInstrument,
+    /// A chordophone, i.e. an instrument where the sound is created by the vibration of strings.
+    #[serde(rename = "String instrument")]
+    StringInstrument,
+    /// An idiophone, i.e. an instrument where the sound is produced by the body of the instrument
+    /// vibrating, or a drum (most membranophones) where the sound is produced by a stretched membrane
+    /// which is struck or rubbed.
+    #[serde(rename = "Percussion instrument")]
+    PercussionInstrument,
+    /// An electrophone, i.e. an instrument where the sound is created with electricity.
+    #[serde(rename = "Electronic instrument")]
+    ElectronicInstrument,
+    /// A grouping of related but different instruments, like the different violin-like instruments.
+    Family,
+    /// A standard grouping of instruments often played together, like a string quartet.
+    Ensemble,
+    /// An instrument which doesn't fit in the categories above.
+    #[serde(rename = "Other instrument")]
+    OtherInstrument,
 }
 
 impl_browse!(Instrument, (by_collection, BrowseBy::Collection));

--- a/src/entity/label.rs
+++ b/src/entity/label.rs
@@ -10,21 +10,30 @@ use crate::entity::BrowseBy;
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub struct Label {
+    /// See [MusicBrainz Identifier](https://musicbrainz.org/doc/MusicBrainz_Identifier).
     pub id: String,
     pub type_id: Option<String>,
+    /// The type describes the main activity of the label.
     #[serde(rename = "type")]
     pub label_type: Option<String>,
+    /// The official name of the label.
     pub name: String,
     pub sort_name: Option<String>,
+    /// The disambiguation comments are fields in the database used to help distinguish identically
+    /// named artists, labels and other entities.
     pub disambiguation: Option<String>,
     pub relations: Option<Vec<Relation>>,
     pub country: Option<String>,
+    /// The label code is the "LC" code of the label.
     pub label_code: Option<u32>,
     pub releases: Option<Vec<Release>>,
+    /// Aliases are used to store alternate names or misspellings.
     pub aliases: Option<Vec<Alias>>,
     pub tags: Option<Vec<Tag>>,
     pub rating: Option<Rating>,
     pub genres: Option<Vec<Genre>>,
+    /// Annotations are text fields, functioning like a miniature wiki, that can be added to any
+    /// existing artists, labels, recordings, releases, release groups and works.
     pub annotation: Option<String>,
 }
 

--- a/src/entity/place.rs
+++ b/src/entity/place.rs
@@ -10,20 +10,35 @@ use crate::entity::BrowseBy;
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub struct Place {
+    /// See [MusicBrainz Identifier](https://musicbrainz.org/doc/MusicBrainz_Identifier).
     pub id: String,
+    /// The place name is the official name of a place.
     pub name: String,
+    /// The type categorises the place based on its primary function. The possible values are:
+    /// Studio, Venue, Stadium, Indoor arena, Religious building, Educational institution,
+    /// Pressing plant, Other.
     #[serde(rename = "type")]
-    pub place_type: Option<String>,
+    pub place_type: Option<PlaceType>,
     pub type_id: Option<String>,
     pub life_span: Option<LifeSpan>,
+    /// The latitude and longitude describe the location of the place using geographic coordinates.
     pub coordinates: Option<Coordinates>,
     pub relations: Option<Vec<Relation>>,
+    /// The area links to the area, such as the city, in which the place is located.
     pub area: Area,
+    /// The address describes the location of the place using the standard addressing format for
+    /// the country it is located in.
     pub address: String,
+    /// The disambiguation comments are fields in the database used to help distinguish identically
+    /// named artists, labels and other entities.
     pub disambiguation: String,
+    /// Aliases are alternate names for a place, which currently have two main functions:
+    /// localised names and search hints.
     pub aliases: Option<Vec<Alias>>,
     pub tags: Option<Vec<Tag>>,
     pub genres: Option<Vec<Genre>>,
+    /// Annotations are text fields, functioning like a miniature wiki, that can be added to any
+    /// existing artists, labels, recordings, releases, release groups and works.
     pub annotation: Option<String>,
 }
 
@@ -31,6 +46,36 @@ pub struct Place {
 pub struct Coordinates {
     pub latitude: f64,
     pub longitude: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub enum PlaceType {
+    /// A place designed for non-live production of music, typically a recording studio.
+    Studio,
+    /// A place that has live artistic performances as one of its primary functions, such as a
+    /// concert hall.
+    Venue,
+    /// A place whose main purpose is to host outdoor sport events, typically consisting of a pitch
+    /// surrounded by a structure for spectators with no roof, or a roof which can be retracted.
+    Stadium,
+    /// A place consisting of a large enclosed area with a central event space surrounded by tiered
+    /// seating for spectators, which can be used for indoor sports, concerts and other entertainment
+    /// events.
+    #[serde(rename = "Indoor arena")]
+    IndoorArena,
+    /// A place mostly designed and used for religious purposes, like a church, cathedral or
+    /// synagogue.
+    #[serde(rename = "Religious building")]
+    ReligiousBuilding,
+    /// A school, university or other similar educational institution (especially, but not only, one
+    /// where music is taught)
+    #[serde(rename = "Educational institution")]
+    EducationalInstitution,
+    /// A place (generally a factory) at which physical media are manufactured.
+    #[serde(rename = "Pressing plant")]
+    PressingPlant,
+    /// Anything which does not fit into the above categories.
+    Other,
 }
 
 impl_browse! {

--- a/src/entity/recording.rs
+++ b/src/entity/recording.rs
@@ -21,30 +21,34 @@ use crate::entity::{Include, Relationship, Subquery};
 pub struct Recording {
     /// See [MusicBrainz Identifier](https://musicbrainz.org/doc/MusicBrainz_Identifier).
     pub id: String,
-
     /// The title of the recording.
     pub title: String,
 
     pub video: Option<bool>,
-
     /// The length of the recording. It's only entered manually for
     /// [standalone recordings](https://musicbrainz.org/doc/Standalone_Recording). For recordings
     /// that are being used on releases, the recording length is the median length of all tracks
     /// (that have a track length) associated with that recording. If there is an even number of
     /// track lengths, the smaller median candidate is used.
     pub length: Option<u32>, // TODO: CUSTOM Deserialized to make this a duration
-
-    /// See Disambiguation Comment.
+    /// The disambiguation comments are fields in the database used to help distinguish identically
+    /// named artists, labels and other entities.
     pub disambiguation: Option<String>,
-
+    /// The International Standard Recording Code assigned to the recording.
     pub isrcs: Option<Vec<String>>,
     pub relations: Option<Vec<Relation>>,
     pub releases: Option<Vec<Release>>,
+    /// Artist credits indicate who is the main credited artist (or artists) for releases, release
+    /// groups, tracks and recordings, and how they are credited.
     pub artist_credit: Option<Vec<ArtistCredit>>,
+    /// Aliases are alternate names for a recording.
     pub aliases: Option<Vec<Alias>>,
     pub tags: Option<Vec<Tag>>,
     pub rating: Option<Rating>,
+    /// Genres are currently supported in MusicBrainz as part of the tag system.
     pub genres: Option<Vec<Genre>>,
+    /// Annotations are text fields, functioning like a miniature wiki, that can be added to any
+    /// existing artists, labels, recordings, releases, release groups and works.
     pub annotation: Option<String>,
 }
 

--- a/src/entity/relations.rs
+++ b/src/entity/relations.rs
@@ -14,22 +14,37 @@ use crate::entity::work::Work;
 use chrono::NaiveDate;
 use std::collections::HashMap;
 
+/// Relationships are a way to represent all the different ways in which entities are connected to
+/// each other and to URLs outside MusicBrainz.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub struct Relation {
     #[serde(deserialize_with = "date_format::deserialize_opt")]
     pub end: Option<NaiveDate>,
+    /// Relationships can have attributes which modify the relationship. There is a
+    /// [list of all attributes](https://musicbrainz.org/relationship-attributes), but the
+    /// attributes which are available, and how they should be used, depends on the relationship
+    /// type, so see the documentation for the relationship you want to use for more information.
     pub attributes: Vec<String>,
     #[serde(flatten)]
     pub content: RelationContent,
     pub attribute_values: HashMap<String, String>,
     pub attribute_ids: HashMap<String, String>,
+    /// There are a huge number of different relationship types. The lists (organised per types of
+    /// entities they connect) can be checked at the
+    /// [relationship type table](https://musicbrainz.org/relationships).
     pub target_type: String,
+    /// Credits allow indicating that, for example, songwriting was credited to an artist's legal
+    /// name, and not his main (performance) name.
     pub target_credit: String,
     pub source_credit: String,
     pub ended: bool,
     pub type_id: String,
     #[serde(deserialize_with = "date_format::deserialize_opt")]
+    /// Some relationships have two date fields, a begin date and an end date, to store the period
+    /// of time during which the relationship applied. The date can be the year, the year and the
+    /// month or the full date. It is optional, so it can also be left blank. As with other attributes,
+    /// see the documentation for the relationship types you are using.
     pub begin: Option<NaiveDate>,
     pub direction: String,
     #[serde(rename = "type")]

--- a/src/entity/release.rs
+++ b/src/entity/release.rs
@@ -56,8 +56,12 @@ pub struct Release {
     /// bad the music itself is - for that, use ratings.
     pub quality: Option<ReleaseQuality>,
 
+    /// The barcode, if the release has one. The most common types found on releases are 12-digit
+    /// UPCs and 13-digit EANs.
     pub barcode: Option<String>,
 
+    /// The disambiguation comments are fields in the database used to help distinguish identically
+    /// named artists, labels and other entities.
     pub disambiguation: Option<String>,
 
     #[serde(rename = "packaging-id")]
@@ -68,19 +72,31 @@ pub struct Release {
     pub packaging: Option<String>, //TODO: This might be an enum needs to test all against all possible values
 
     pub relations: Option<Vec<Relation>>,
+    /// The release group associated with this release.
     pub release_group: Option<ReleaseGroup>,
+    /// Artist credits indicate who is the main credited artist (or artists) for releases, release
+    /// groups, tracks and recordings, and how they are credited.
     pub artist_credit: Option<Vec<ArtistCredit>>,
     pub media: Option<Vec<Media>>,
+    /// The label which issued the release. There may be more than one.
     pub label_info: Option<Vec<LabelInfo>>,
     pub tags: Option<Vec<Tag>>,
+    /// Aliases are alternate names for a release.
     pub aliases: Option<Vec<Alias>>,
+    /// Genres are currently supported in MusicBrainz as part of the tag system.
     pub genres: Option<Vec<Genre>>,
+    /// Annotations are text fields, functioning like a miniature wiki, that can be added to any
+    /// existing artists, labels, recordings, releases, release groups and works.
     pub annotation: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct ReleaseTextRepresentation {
+    /// The language a release's track list is written in. The possible values are taken from the ISO
+    /// 639-3 standard.
     pub language: Language,
+    /// The script used to write the release's track list. The possible values are taken from the
+    /// ISO 15924 standard.
     pub script: ReleaseScript,
 }
 
@@ -156,6 +172,8 @@ pub struct Media {
     pub tracks: Option<Vec<Track>>,
 }
 
+/// A track is the way a recording is represented on a particular release (or, more exactly, on a
+/// particular medium).
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub struct Track {

--- a/src/entity/release_group.rs
+++ b/src/entity/release_group.rs
@@ -11,6 +11,8 @@ use crate::entity::BrowseBy;
 use chrono::NaiveDate;
 use lucene_query_builder::QueryBuilder;
 
+/// A release group, just as the name suggests, is used to group several different releases into a
+/// single logical entity. Every release belongs to one, and only one release group.
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 #[serde(default)]
@@ -34,15 +36,25 @@ pub struct ReleaseGroup {
     /// The title of a release group is usually very similar, if not the same, as the titles of the
     /// releases contained within it.
     pub title: String,
-    /// See Disambiguation Comment.
+    /// The disambiguation comments are fields in the database used to help distinguish identically
+    /// named artists, labels and other entities.
     pub disambiguation: String,
+    /// Relationships are a way to represent all the different ways in which entities are connected
+    /// to each other and to URLs outside MusicBrainz.
     pub relations: Option<Vec<Relation>>,
+    /// Artist credits indicate who is the main credited artist (or artists) for releases, release
+    /// groups, tracks and recordings, and how they are credited..
     pub artist_credit: Option<Vec<ArtistCredit>>,
+    /// Releases present in this release group.
     pub releases: Option<Vec<Release>>,
     pub tags: Option<Vec<Tag>>,
     pub rating: Option<Rating>,
+    /// Aliases are alternate names for a release group.
     pub aliases: Option<Vec<Alias>>,
+    /// Genres are currently supported in MusicBrainz as part of the tag system.
     pub genres: Option<Vec<Genre>>,
+    /// Annotations are text fields, functioning like a miniature wiki, that can be added to any
+    /// existing artists, labels, recordings, releases, release groups and works.
     pub annotation: Option<String>,
 }
 

--- a/src/entity/series.rs
+++ b/src/entity/series.rs
@@ -5,19 +5,37 @@ use crate::entity::relations::Relation;
 use crate::entity::tag::Tag;
 use crate::entity::BrowseBy;
 
+/// A series is a sequence of separate release groups, releases, recordings, works, artists or
+/// events with a common theme.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub struct Series {
+    /// See [MusicBrainz Identifier](https://musicbrainz.org/doc/MusicBrainz_Identifier).
     pub id: String,
+    /// The series name is the official name of the series.
     pub name: String,
     #[serde(rename = "type")]
+    /// The type primarily describes what type of entity the series contains. The possible values are:
+    /// Release group series, Release series, Recording series, Work series (with further subtypes:
+    /// Catalogue), Artist series (with further subtypes: Artist award), Event series (with further
+    /// subtypes: Tour, Festival, Run, Residency)
+    // FIXME: Can we use a `SeriesType` enum here?
     pub series_type: String,
+    /// The disambiguation comments are fields in the database used to help distinguish identically
+    /// named artists, labels and other entities.
     pub disambiguation: String,
     pub type_id: String,
+    /// Relationships are a way to represent all the different ways in which entities are connected
+    /// to each other and to URLs outside MusicBrainz.
     pub relations: Option<Vec<Relation>>,
     pub tags: Option<Vec<Tag>>,
+    /// Aliases are alternate names for a series, which currently have two main functions: localised
+    /// names and search hints.
     pub aliases: Option<Vec<Alias>>,
+    /// Genres are currently supported in MusicBrainz as part of the tag system.
     pub genres: Option<Vec<Genre>>,
+    /// Annotations are text fields, functioning like a miniature wiki, that can be added to any
+    /// existing artists, labels, recordings, releases, release groups and works.
     pub annotation: Option<String>,
 }
 

--- a/src/entity/url.rs
+++ b/src/entity/url.rs
@@ -1,6 +1,13 @@
 use super::{Include, Relationship};
 use crate::entity::tag::Tag;
 
+/// A URL in MusicBrainz is a specific entity representing a regular internet Uniform Resource Locator.
+/// A MusicBrainz URL entity can be edited to change the underlying internet URL it points to; and can
+/// be linked to Areas, Artists, Events, Instruments, Labels, Places, Recordings, Releases, Release
+/// Groups, and Series.
+
+/// Take a look at the [relationship table](https://musicbrainz.org/relationships) on the MusicBrainz
+/// server to see all types.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Url {
     pub id: String,

--- a/src/entity/work.rs
+++ b/src/entity/work.rs
@@ -17,16 +17,25 @@ pub struct Work {
     pub id: String,
     pub title: String,
     pub type_id: Option<String>,
+    /// Works are represented predominantly at two levels: Discrete works, Aggregate works.
+    // FIXME: Can we use a `WorkType` enum here?
     #[serde(rename = "type")]
     pub work_type: Option<String>,
     pub language: Option<String>,
     pub languages: Option<Vec<String>>,
+    /// The disambiguation comments are fields in the database used to help distinguish identically
+    /// named artists, labels and other entities.
     pub disambiguation: Option<String>,
     pub relations: Option<Vec<Relation>>,
     pub tags: Option<Vec<Tag>>,
     pub rating: Option<Rating>,
+    /// If a discrete work is known by name(s) or in language(s) other than its canonical name,
+    /// these are specified in the work’s aliases.
     pub aliases: Option<Vec<Alias>>,
+    /// Genres are currently supported in MusicBrainz as part of the tag system.
     pub genres: Option<Vec<Genre>>,
+    /// Annotations are text fields, functioning like a miniature wiki, that can be added to any
+    /// existing artists, labels, recordings, releases, release groups and works.
     pub annotation: Option<String>,
 }
 

--- a/tests/fetch.rs
+++ b/tests/fetch.rs
@@ -4,13 +4,16 @@ extern crate musicbrainz_rs;
 use chrono::NaiveDate;
 use std::collections::HashMap;
 
+use musicbrainz_rs::entity::area::AreaType::*;
 use musicbrainz_rs::entity::area::*;
 use musicbrainz_rs::entity::artist::ArtistType::*;
 use musicbrainz_rs::entity::artist::*;
 use musicbrainz_rs::entity::event::Event;
+use musicbrainz_rs::entity::instrument::InstrumentType::*;
 use musicbrainz_rs::entity::instrument::*;
 use musicbrainz_rs::entity::label::*;
 use musicbrainz_rs::entity::lifespan::*;
+use musicbrainz_rs::entity::place::PlaceType::*;
 use musicbrainz_rs::entity::place::*;
 use musicbrainz_rs::entity::recording::Recording;
 use musicbrainz_rs::entity::relations::*;
@@ -290,7 +293,7 @@ fn should_get_area_by_id() {
         aberdeen.unwrap(),
         Area {
             id: "a640b45c-c173-49b1-8030-973603e895b5".to_string(),
-            area_type: Some("City".to_string()),
+            area_type: Some(City),
             type_id: Some("6fd8f29a-3d0a-32fc-980d-ea697b69da78".to_string()),
             disambiguation: "".to_string(),
             name: "Aberdeen".to_string(),
@@ -353,7 +356,7 @@ fn should_get_instrument() {
         Instrument {
             id: "37fa9bb5-d5d7-4b0f-aa4d-531339ba9c32".to_string(),
             name: "mandolin".to_string(),
-            instrument_type: "String instrument".to_string(),
+            instrument_type: StringInstrument,
             type_id: "cc00f97f-cf3d-3ae2-9163-041cb1a0d726".to_string(),
             description: "".to_string(),
             disambiguation: "".to_string(),
@@ -384,7 +387,7 @@ fn should_get_place() {
                 ended: Some(true),
             }),
             type_id: Some("cd92781a-a73f-30e8-a430-55d7521338db".to_string()),
-            place_type: Some("Venue".to_string()),
+            place_type: Some(Venue),
             address: "3 North Clark Street, Chicago, IL 60602".to_string(),
             area: Area {
                 id: "29a709d8-0320-493e-8d0c-f2c386662b7f".to_string(),


### PR DESCRIPTION
I've also been introducing new enums for the fields which can have only have one specific value assigned to them from the multiple values known beforehand.