### PR TITLE
feat(release): support `artist_credits` subquery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,17 @@ MusicBrainz API.
 travis-ci = { repository = "oknozor/musicbrainz_rs", branch = "master" }
 
 [dependencies]
-
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-reqwest = "0.9.18"
+reqwest = { version = "0.11.11", default-features = false, features = ["blocking", "json"] }
 chrono = { version = "0.4", features = ["serde"] }
 lazy_static = "1.3.0"
 lucene_query_builder = "0.3.0"
+
+[features]
+default = ["reqwest/default-tls"]
+rustls = ["reqwest/rustls"]
 
 [[example]]
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,6 @@
+use reqwest::blocking::{Client, RequestBuilder, Response};
 use reqwest::header;
-use reqwest::Client;
 use reqwest::Error;
-use reqwest::RequestBuilder;
-use reqwest::Response;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::{thread, time::Duration};
@@ -56,9 +54,9 @@ fn init_http_client() -> MusicBrainzClient {
         header::HeaderValue::from_static("musicbrainz_rs default"),
     );
 
-    let client = reqwest::Client::builder()
+    let client = reqwest::blocking::Client::builder()
         // see : https://github.com/hyperium/hyper/issues/2136
-        .max_idle_per_host(0)
+        .pool_max_idle_per_host(0)
         .default_headers(headers)
         .build().expect("Unable to set default user agent, the following values must be set in Cargo.toml : 'name', 'version', 'authors'");
 
@@ -96,7 +94,7 @@ pub fn set_user_agent(user_agent: &'static str) {
         header::HeaderValue::from_static(user_agent),
     );
 
-    *client_lock = reqwest::Client::builder()
+    *client_lock = Client::builder()
         .default_headers(headers)
         .build()
         .expect("Unable to set user agent");

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,16 +60,12 @@ fn init_http_client() -> MusicBrainzClient {
         .default_headers(headers)
         .build().expect("Unable to set default user agent, the following values must be set in Cargo.toml : 'name', 'version', 'authors'");
 
-    MusicBrainzClient {
-        0: Arc::new(Mutex::new(client)),
-    }
+    MusicBrainzClient(Arc::new(Mutex::new(client)))
 }
 
 fn init_http_retries() -> MusicBrainzRetries {
     let retries = 2;
-    MusicBrainzRetries {
-        0: Arc::new(Mutex::new(retries)),
-    }
+    MusicBrainzRetries(Arc::new(Mutex::new(retries)))
 }
 
 /// Each request sent to MusicBrainz needs to include a User-Agent header,

--- a/src/entity/alias.rs
+++ b/src/entity/alias.rs
@@ -3,7 +3,7 @@ use chrono::NaiveDate;
 
 /// Aliases are used to store alternate names or misspellings. For more information and examples,
 /// see the page about [aliases](https://musicbrainz.org/doc/Aliases).
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Default)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Default)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 #[serde(default)]
 pub struct Alias {

--- a/src/entity/annotation.rs
+++ b/src/entity/annotation.rs
@@ -8,7 +8,7 @@ use lucene_query_builder::QueryBuilder;
 /// The content of an annotation can be edited by any MusicBrainz user. Like the rest of the database,
 /// if something is incorrect or incomplete, you can fix it. All changes are recorded and if someone
 /// deletes or defaces the annotation, you can easily restore a previous copy.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub struct Annotation {
     /// the annotated entity's MBID

--- a/src/entity/artist.rs
+++ b/src/entity/artist.rs
@@ -164,47 +164,47 @@ impl Default for Gender {
 #[derive(Debug, QueryBuilder, Default)]
 pub struct ArtistSearchQuery {
     /// (part of) any alias attached to the artist (diacritics are ignored)
-    alias: String,
+    pub alias: String,
     /// (part of) any primary alias attached to the artist (diacritics are ignored)
     #[query_builder_field = "primaryalias"]
-    primary_alias: String,
+    pub primary_alias: String,
     /// (part of) the name of the artist's main associated area
-    area: String,
+    pub area: String,
     /// the artist's MBID
-    arid: String,
+    pub arid: String,
     /// (part of) the artist's name (diacritics are ignored)
-    artist: String,
+    pub artist: String,
     /// (part of) the artist's name (with the specified diacritics)
-    artist_accent: String,
+    pub artist_accent: String,
     /// the artist's begin date (e.g. "1980-01-22")
-    begin: Option<NaiveDate>,
+    pub begin: Option<NaiveDate>,
     /// (part of) the name of the artist's begin area
-    begin_area: String,
+    pub begin_area: String,
     /// (part of) the artist's disambiguation comment
-    comment: String,
+    pub comment: String,
     /// the 2-letter code (ISO 3166-1 alpha-2) for the artist's main associated country
-    country: String,
+    pub country: String,
     /// the artist's end date (e.g. "1980-01-22")
-    end: Option<NaiveDate>,
+    pub end: Option<NaiveDate>,
     /// (part of) the name of the artist's end area
     #[query_builder_field = "end_area"]
-    end_area: String,
+    pub end_area: String,
     /// a boolean flag (true/false) indicating whether or not the artist has ended (is dissolved/deceased)
-    ended: bool,
+    pub ended: bool,
     /// the artist's gender (“male”, “female”, “other” or “not applicable”)
-    gender: Option<Gender>,
+    pub gender: Option<Gender>,
     /// an IPI code associated with the artist
-    ipi: String,
+    pub ipi: String,
     /// an ISNI code associated with the artist
-    isni: String,
+    pub isni: String,
     /// (part of) the artist's sort name
     #[query_builder_field = "sortname"]
-    sort_name: Option<String>,
+    pub sort_name: Option<String>,
     /// (part of) a tag attached to the artist
-    tag: String,
+    pub tag: String,
     /// the artist's type (“person”, “group”, etc.)
     #[query_builder_field = "type"]
-    artist_type: Option<ArtistType>,
+    pub artist_type: Option<ArtistType>,
 }
 
 impl_browse! {

--- a/src/entity/cdstub.rs
+++ b/src/entity/cdstub.rs
@@ -2,7 +2,7 @@ use lucene_query_builder::QueryBuilder;
 
 /// A CD stub is an anonymously submitted track list that contains a disc ID, barcode, comment
 /// field, and basic metadata like a release title and track names.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub struct CDStub {
     /// See [MusicBrainz Identifier](https://musicbrainz.org/doc/MusicBrainz_Identifier).

--- a/src/entity/coverart.rs
+++ b/src/entity/coverart.rs
@@ -1,9 +1,9 @@
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Coverart {
     pub images: Vec<CoverartImage>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct CoverartImage {
     pub approved: bool,
     pub back: bool,
@@ -16,7 +16,7 @@ pub struct CoverartImage {
     pub types: Vec<ImageType>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Thumbnail {
     /// This is now deprecated in MusicBrainz API. Use `res_250` instead.
     pub small: Option<String>,
@@ -31,7 +31,7 @@ pub struct Thumbnail {
     pub res_250: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub enum ImageType {
     /// The album cover, this is the front of the packaging of an audio recording (or in the
     /// case of a digital release the image associated with it in a digital media store).

--- a/src/entity/genre.rs
+++ b/src/entity/genre.rs
@@ -1,7 +1,7 @@
 /// Genres are currently supported in MusicBrainz as part of the tag system.
 /// See [Genre](https://musicbrainz.org/doc/Genre) and
 /// [supported genres](https://musicbrainz.org/genres) for more information.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub struct Genre {
     pub count: u32,

--- a/src/entity/lifespan.rs
+++ b/src/entity/lifespan.rs
@@ -1,7 +1,7 @@
 use crate::date_format;
 use chrono::NaiveDate;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Default)]
 #[serde(default)]
 pub struct LifeSpan {
     pub ended: Option<bool>,
@@ -11,14 +11,4 @@ pub struct LifeSpan {
     #[serde(default)]
     #[serde(deserialize_with = "date_format::deserialize_opt")]
     pub end: Option<NaiveDate>,
-}
-
-impl Default for LifeSpan {
-    fn default() -> Self {
-        LifeSpan {
-            ended: None,
-            begin: None,
-            end: None,
-        }
-    }
 }

--- a/src/entity/lifespan.rs
+++ b/src/entity/lifespan.rs
@@ -1,7 +1,7 @@
 use crate::date_format;
 use chrono::NaiveDate;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Default)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Default)]
 #[serde(default)]
 pub struct LifeSpan {
     pub ended: Option<bool>,

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -51,10 +51,9 @@ macro_rules! impl_browse {
     ($ty: ty, $(($args:ident, $browse: expr)),+) => {
         impl BrowseQuery<$ty> {
                $(pub fn $args(&mut self, id: &str) -> &mut Self  {
+                    use std::fmt::Write as _;
                     self.0.path.push_str(crate::config::FMT_JSON);
-                    self.0
-                    .path
-                    .push_str(&format!("&{}={}",$browse.as_str(), id));
+                    let _ = write!(self.0.path, "&{}={}", $browse.as_str(), id);
                     self
                })*
             }
@@ -372,7 +371,7 @@ impl BrowseBy {
 
 /// Browse query result are wrapped in this generic struct and paired with a custom
 /// Deserialize implementation to avoid reimplementing a custom deserializer for every entity.
-#[derive(Debug, Serialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, PartialEq, Eq, Clone)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub struct BrowseResult<T> {
     pub count: i32,

--- a/src/entity/release.rs
+++ b/src/entity/release.rs
@@ -360,5 +360,8 @@ impl_includes!(
     (with_aliases, Include::Subquery(Subquery::Aliases)),
     (with_genres, Include::Subquery(Subquery::Genres)),
     (with_annotations, Include::Subquery(Subquery::Annotations)),
-    (with_artist_credits, Include::Subquery(Subquery::ArtistCredits))
+    (
+        with_artist_credits,
+        Include::Subquery(Subquery::ArtistCredits)
+    )
 );

--- a/src/entity/release.rs
+++ b/src/entity/release.rs
@@ -359,5 +359,6 @@ impl_includes!(
     (with_ratings, Include::Subquery(Subquery::Rating)),
     (with_aliases, Include::Subquery(Subquery::Aliases)),
     (with_genres, Include::Subquery(Subquery::Genres)),
-    (with_annotations, Include::Subquery(Subquery::Annotations))
+    (with_annotations, Include::Subquery(Subquery::Annotations)),
+    (with_artist_credits, Include::Subquery(Subquery::ArtistCredits))
 );

--- a/src/entity/release.rs
+++ b/src/entity/release.rs
@@ -90,7 +90,7 @@ pub struct Release {
     pub annotation: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct ReleaseTextRepresentation {
     /// The language a release's track list is written in. The possible values are taken from the ISO
     /// 639-3 standard.
@@ -102,7 +102,7 @@ pub struct ReleaseTextRepresentation {
 
 /// The script used to write the release's track list. The possible values are taken from the
 /// [ISO 15924](https://en.wikipedia.org/wiki/ISO_15924) standard.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub enum ReleaseScript {
     /* TODO: we need to test all posible values to build the enum see https://musicbrainz.org/doc/Release */
     /// ## Latin (also known as Roman or, incorrectly, "English")
@@ -112,12 +112,12 @@ pub enum ReleaseScript {
 }
 
 /* TODO: we need to test all posible values to build the enum see https://musicbrainz.org/doc/Release */
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub enum Language {
     Eng,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all(deserialize = "lowercase"))]
 pub enum ReleaseQuality {
     /// The release needs serious fixes, or its existence is hard to prove (but it's not clearly fake).

--- a/src/entity/release_group.rs
+++ b/src/entity/release_group.rs
@@ -107,49 +107,49 @@ pub enum ReleaseGroupSecondaryType {
 #[derive(Debug, QueryBuilder, Default)]
 pub struct ReleaseGroupSearchQuery {
     /// (part of) any alias attached to the release group (diacritics are ignored)
-    alias: String,
+    pub alias: String,
     /// the MBID of any of the release group artists
-    arid: String,
+    pub arid: String,
     /// (part of) the combined credited artist name for the release group, including join phrases (e.g. "Artist X feat.")
-    artist: String,
+    pub artist: String,
     /// (part of) the name of any of the release group artists
     #[query_builder_field = "artistname"]
-    artist_name: String,
+    pub artist_name: String,
     /// (part of) the release group's disambiguation comment
-    comment: String,
+    pub comment: String,
     /// (part of) the credited name of any of the release group artists on this particular release group
     #[query_builder_field = "creditname"]
-    credit_name: String,
+    pub credit_name: String,
     /// the release date of the earliest release in this release group (e.g. "1980-01-22")
     #[query_builder_field = "firstreleasedate"]
-    first_release_date: String,
+    pub first_release_date: String,
     /// the primary type of the release group
     #[query_builder_field = "primarytype"]
-    primary_type: String,
+    pub primary_type: String,
     /// the MBID of any of the releases in the release group
-    reid: String,
+    pub reid: String,
     /// (part of) the title of any of the releases in the release group
-    release: String,
+    pub release: String,
     /// (part of) the release group's title (diacritics are ignored)
     #[query_builder_field = "releasegroup"]
-    release_group: String,
+    pub release_group: String,
     /// (part of) the release group's title (with the specified diacritics)
     #[query_builder_field = "releasegroupaccent"]
-    release_group_accent: String,
+    pub release_group_accent: String,
     /// the number of releases in the release group
-    releases: String,
+    pub releases: String,
     /// the release group's MBID
-    rgid: String,
+    pub rgid: String,
     /// any of the secondary types of the release group
     #[query_builder_field = "secondarytype"]
-    secondary_type: String,
+    pub secondary_type: String,
     /// the status of any of the releases in the release group
-    status: String,
+    pub status: String,
     /// the status of any of the releases in the release group
-    tag: String,
+    pub tag: String,
     /// legacy release group type field that predates the ability to set multiple types (see calculation code)
     #[query_builder_field = "type"]
-    release_type: String,
+    pub release_type: String,
 }
 
 impl_browse! {

--- a/src/entity/search.rs
+++ b/src/entity/search.rs
@@ -12,7 +12,7 @@ use crate::entity::series::Series;
 use crate::entity::work::Work;
 use chrono::NaiveDateTime;
 
-#[derive(Debug, Serialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, PartialEq, Eq, Clone)]
 #[serde(rename_all(deserialize = "kebab-case"))]
 pub struct SearchResult<T> {
     pub created: NaiveDateTime,

--- a/src/entity/tag.rs
+++ b/src/entity/tag.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Tag {
     pub name: String,
     pub count: i32,

--- a/src/entity/url.rs
+++ b/src/entity/url.rs
@@ -8,7 +8,7 @@ use crate::entity::tag::Tag;
 
 /// Take a look at the [relationship table](https://musicbrainz.org/relationships) on the MusicBrainz
 /// server to see all types.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Url {
     pub id: String,
     pub resource: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,7 +271,7 @@ where
         let coverart_response: CoverartResponse;
         self.validate();
         let request = HTTP_CLIENT.get(&self.0.path);
-        let mut response = HTTP_CLIENT.send_with_retries(request)?;
+        let response = HTTP_CLIENT.send_with_retries(request)?;
         if self.0.target.img_type.is_some() {
             let url = response.url().clone();
             coverart_response = CoverartResponse::Url(url.to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,16 +268,15 @@ where
     }
 
     pub fn execute(&mut self) -> Result<CoverartResponse, Error> {
-        let coverart_response: CoverartResponse;
         self.validate();
         let request = HTTP_CLIENT.get(&self.0.path);
         let response = HTTP_CLIENT.send_with_retries(request)?;
-        if self.0.target.img_type.is_some() {
+        let coverart_response = if self.0.target.img_type.is_some() {
             let url = response.url().clone();
-            coverart_response = CoverartResponse::Url(url.to_string());
+            CoverartResponse::Url(url.to_string())
         } else {
-            coverart_response = CoverartResponse::Json(response.json().unwrap());
-        }
+            CoverartResponse::Json(response.json().unwrap())
+        };
         Ok(coverart_response)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ use entity::Browsable;
 use entity::BrowseResult;
 use entity::Include;
 use entity::{CoverartResolution, CoverartResponse, CoverartTarget, CoverartType};
+use std::fmt::Write as _;
 
 /// Type alias for [reqwest::Error]
 pub type Error = reqwest::Error;
@@ -186,7 +187,7 @@ where
     T: Clone,
 {
     pub fn id(&mut self, id: &str) -> &mut Self {
-        self.0.path.push_str(&format!("/{}", id));
+        let _ = write!(self.0.path, "/{id}");
         self
     }
 
@@ -210,7 +211,7 @@ where
     T: Clone + FetchCoverart<'a>,
 {
     pub fn id(&mut self, id: &str) -> &mut Self {
-        self.0.path.push_str(&format!("/{}", id));
+        let _ = write!(self.0.path, "/{id}");
         self
     }
 
@@ -256,9 +257,9 @@ where
 
     pub fn validate(&mut self) {
         if let Some(img_type) = &self.0.target.img_type {
-            self.0.path.push_str(&format!("/{}", img_type.as_str()));
+            let _ = write!(self.0.path, "/{}", img_type.as_str());
             if let Some(img_res) = &self.0.target.img_res {
-                self.0.path.push_str(&format!("-{}", img_res.as_str()));
+                let _ = write!(self.0.path, "-{}", img_res.as_str());
             }
         } else if self.0.target.img_res.is_some() {
             // Implicitly assume coverart type as front in the case when resolution is
@@ -317,7 +318,7 @@ where
     }
 }
 
-impl<'a, T> Query<T> {
+impl<T> Query<T> {
     fn include(&mut self, include: Include) -> &mut Self {
         self.include.push(include);
         self

--- a/tests/artist/artist_includes.rs
+++ b/tests/artist/artist_includes.rs
@@ -16,7 +16,7 @@ fn should_get_artist_releases() {
 
     assert!(releases
         .iter()
-        .any(|release| release.title == "Boogie Chillen’ / Sally Mae"));
+        .any(|release| release.title == "Sally Mae / Boogie Chillen’"));
 }
 
 #[test]

--- a/tests/cdstub/cdstub_search.rs
+++ b/tests/cdstub/cdstub_search.rs
@@ -12,5 +12,5 @@ fn should_search_cdstub() {
     assert!(result
         .entities
         .iter()
-        .any(|cdstub| cdstub.artist == "Green Day"));
+        .any(|cdstub| cdstub.artist == "Cleatus and Jimmy"));
 }

--- a/tests/label/label_includes.rs
+++ b/tests/label/label_includes.rs
@@ -14,7 +14,7 @@ fn should_get_label_releases() {
     assert!(releases
         .unwrap()
         .iter()
-        .any(|release| release.title == "The Final Corporate Colonization of the Unconscious"));
+        .any(|release| release.title == "Zen Brakes, Volume 1"));
 }
 
 #[test]

--- a/tests/release/release_includes.rs
+++ b/tests/release/release_includes.rs
@@ -40,7 +40,7 @@ fn should_get_release_recordings() {
         .unwrap();
 
     let medias: Vec<Media> = justice_cross.media.unwrap();
-    let cd = medias.iter().next().unwrap();
+    let cd = medias.first().unwrap();
 
     assert!(cd
         .tracks

--- a/tests/release_group/release_group_includes.rs
+++ b/tests/release_group/release_group_includes.rs
@@ -43,7 +43,7 @@ fn should_get_release_group_tags() {
         .tags
         .unwrap()
         .iter()
-        .any(|tag| tag.name == "rock_grunge"));
+        .any(|tag| tag.name == "noise rock"));
 }
 
 #[test]


### PR DESCRIPTION
I found artist information is not included when fetching a release and adding `artist-credits`(or `artists`) to subquery fixes that.
This pr adds `with_artist_credits` to `Release`.